### PR TITLE
Fix/add missingfortran io

### DIFF
--- a/apps/c/airfoil/airfoil_hdf5/dp/airfoil.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/airfoil.cpp
@@ -218,15 +218,15 @@ int main(int argc, char **argv)
   }
 
   op_timers(&cpu_t2, &wall_t2);
-  
-  //write given op_dat's indicated segment of data to a memory block in the order it was originally 
+
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
   //arranged (i.e. before partitioning and reordering)
   double* q = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
-  op_fetch_data_hdf5(p_q, q, 0, op_get_size(cells)-1);
+  op_fetch_data_idx(p_q, q, 0, op_get_size(cells)-1);
   free(q);
 
   //write given op_dat's data to hdf5 file in the order it was originally arranged (i.e. before partitioning and reordering)
-  op_fetch_data_hdf5_file(p_q, "file_name.h5"); 
+  op_fetch_data_hdf5_file(p_q, "file_name.h5");
 
   //printf("Root process = %d\n",op_is_root());
 

--- a/apps/c/airfoil/airfoil_hdf5/dp/airfoil_op.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/airfoil_op.cpp
@@ -270,15 +270,15 @@ int main(int argc, char **argv)
   }
 
   op_timers(&cpu_t2, &wall_t2);
-  
-  //write given op_dat's indicated segment of data to a memory block in the order it was originally 
+
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
   //arranged (i.e. before partitioning and reordering)
   double* q = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
-  op_fetch_data_hdf5(p_q, q, 0, op_get_size(cells)-1);
+  op_fetch_data_idx(p_q, q, 0, op_get_size(cells)-1);
   free(q);
 
   //write given op_dat's data to hdf5 file in the order it was originally arranged (i.e. before partitioning and reordering)
-  op_fetch_data_hdf5_file(p_q, "file_name.h5"); 
+  op_fetch_data_hdf5_file(p_q, "file_name.h5");
 
   //printf("Root process = %d\n",op_is_root());
 

--- a/apps/c/airfoil/airfoil_plain/dp/airfoil.cpp
+++ b/apps/c/airfoil/airfoil_plain/dp/airfoil.cpp
@@ -268,6 +268,12 @@ int main(int argc, char **argv)
   op_print_dat_to_txtfile(p_q, "out_grid_seq.dat"); //ASCI
   op_print_dat_to_binfile(p_q, "out_grid_seq.bin"); //Binary
 
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
+  //arranged (i.e. before partitioning and reordering)
+  double* q_part = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
+  op_fetch_data_idx(p_q, q_part, 0, op_get_size(cells)-1);
+  free(q_part);
+
   op_timing_output();
   op_printf("Max total runtime = \n%f\n",wall_t2-wall_t1);
 

--- a/apps/c/airfoil/airfoil_plain/dp/airfoil_mpi.cpp
+++ b/apps/c/airfoil/airfoil_plain/dp/airfoil_mpi.cpp
@@ -415,6 +415,12 @@ int main(int argc, char **argv)
   op_print_dat_to_txtfile(p_q, "out_grid_mpi.dat"); //ASCI
   op_print_dat_to_binfile(p_q, "out_grid_mpi.bin"); //Binary
 
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
+  //arranged (i.e. before partitioning and reordering)
+  double* q_part = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
+  op_fetch_data_idx(p_q, q_part, 0, op_get_size(cells)-1);
+  free(q_part);
+
   op_timing_output();
   op_printf("Max total runtime = %f\n",wall_t2-wall_t1);
 

--- a/apps/c/airfoil/airfoil_plain/dp/airfoil_mpi_op.cpp
+++ b/apps/c/airfoil/airfoil_plain/dp/airfoil_mpi_op.cpp
@@ -467,6 +467,12 @@ int main(int argc, char **argv)
   op_print_dat_to_txtfile(p_q, "out_grid_mpi.dat"); //ASCI
   op_print_dat_to_binfile(p_q, "out_grid_mpi.bin"); //Binary
 
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
+  //arranged (i.e. before partitioning and reordering)
+  double* q_part = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
+  op_fetch_data_idx(p_q, q_part, 0, op_get_size(cells)-1);
+  free(q_part);
+
   op_timing_output();
   op_printf("Max total runtime = %f\n",wall_t2-wall_t1);
 

--- a/apps/c/airfoil/airfoil_plain/dp/airfoil_op.cpp
+++ b/apps/c/airfoil/airfoil_plain/dp/airfoil_op.cpp
@@ -320,6 +320,12 @@ int main(int argc, char **argv)
   op_print_dat_to_txtfile(p_q, "out_grid_seq.dat"); //ASCI
   op_print_dat_to_binfile(p_q, "out_grid_seq.bin"); //Binary
 
+  //write given op_dat's indicated segment of data to a memory block in the order it was originally
+  //arranged (i.e. before partitioning and reordering)
+  double* q_part = (double *)op_malloc(sizeof(double)*op_get_size(cells)*4);
+  op_fetch_data_idx(p_q, q_part, 0, op_get_size(cells)-1);
+  free(q_part);
+
   op_timing_output();
   op_printf("Max total runtime = \n%f\n",wall_t2-wall_t1);
 

--- a/apps/c/jac1/dp/jac_mpi.cpp
+++ b/apps/c/jac1/dp/jac_mpi.cpp
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
 
   //gather results from all ranks and check
   double* ug = (double *)malloc(sizeof(double)*op_get_size(nodes));
-  op_fetch_data_hdf5(p_u, ug, 0, op_get_size(nodes)-1);
+  op_fetch_data_idx(p_u, ug, 0, op_get_size(nodes)-1);
   int result = check_result<double>(ug, NN, TOLERANCE);
   free(ug);
 

--- a/apps/c/jac1/sp/jac_mpi.cpp
+++ b/apps/c/jac1/sp/jac_mpi.cpp
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
 
   //gather results from all ranks and check
   float* ug = (float *)malloc(sizeof(float)*op_get_size(nodes));
-  op_fetch_data_hdf5(p_u, ug, 0, op_get_size(nodes)-1);
+  op_fetch_data_idx(p_u, ug, 0, op_get_size(nodes)-1);
   int result = check_result<float>(ug, NN, TOLERANCE);
   free(ug);
 

--- a/apps/c/jac2/jac_mpi.cpp
+++ b/apps/c/jac2/jac_mpi.cpp
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
 
   //gather results from all ranks and check
   float* ug = (float *)malloc(sizeof(float)*op_get_size(nodes));
-  op_fetch_data_hdf5(p_u, ug, 0, op_get_size(nodes)-1);
+  op_fetch_data_idx(p_u, ug, 0, op_get_size(nodes)-1);
   int result = check_result<float>(ug, NN, TOLERANCE);
   free(ug);
 

--- a/apps/fortran/airfoil/airfoil_plain/dp/Makefile
+++ b/apps/fortran/airfoil/airfoil_plain/dp/Makefile
@@ -114,6 +114,7 @@ clean:
 	rm -f *.mod
 	rm -f $(EXEC)
 	rm -f *~
+	rm -f airfoil_genseq
 	rm -f airfoil_seq
 	rm -f airfoil_vec
 	rm -f airfoil_openmp_*

--- a/apps/fortran/airfoil/airfoil_plain/dp/Makefile
+++ b/apps/fortran/airfoil/airfoil_plain/dp/Makefile
@@ -120,3 +120,4 @@ clean:
 	rm -f airfoil_openmp_*
 	rm -f airfoil_openmp_$(PART_SIZE_ENV)
 	rm -f airfoil_cuda
+

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
@@ -104,7 +104,7 @@ program AIRFOIL
   call op_decl_const(alpha, 1, 'alpha')
   call op_decl_const(qinf, 4, 'qinf')
 
-  call op_dump_to_hdf5("new_grid_out.h5")
+  !call op_dump_to_hdf5("new_grid_out.h5")
   !call op_fetch_data_hdf5_file(p_x, "new_grid_out.h5")
 
   ! start timer
@@ -175,6 +175,7 @@ program AIRFOIL
 
   end do ! external loop
 
+  call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
@@ -176,6 +176,7 @@ program AIRFOIL
   end do ! external loop
 
   call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
+  call op_fetch_data(p_q, q)
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
@@ -95,6 +95,7 @@ program AIRFOIL
   call op_decl_dat ( cells, 1, 'real(8)', adt, p_adt, 'p_adt' )
   call op_decl_dat ( cells, 4, 'real(8)', res, p_res, 'p_res' )
 
+
   print *, "Declaring OP2 constants"
   call op_decl_const(gam, 1, 'gam')
   call op_decl_const(gm1, 1, 'gm1')
@@ -162,6 +163,8 @@ program AIRFOIL
                          & op_arg_gbl (rms, 2, "real(8)", OP_INC))
 
 
+      call op_fetch_data(p_q,q)
+    
     end do ! internal loop
 
     ncellr = real ( ncell )
@@ -175,8 +178,6 @@ program AIRFOIL
 
   end do ! external loop
 
-  call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
-  call op_fetch_data(p_q, q)
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
@@ -37,7 +37,7 @@ program AIRFOIL
 
   ! arrays used in data
   integer(4), dimension(:), allocatable, target :: ecell, bound, edge, bedge, becell, cell
-  real(8), dimension(:), allocatable, target :: x, q, qold, adt, res
+  real(8), dimension(:), allocatable, target :: x, q, qold, adt, res, q_part
   real(8), dimension(1:2) :: rms
 
   integer(4) :: debugiter, retDebug
@@ -62,6 +62,9 @@ program AIRFOIL
   allocate ( qold ( 4 * ncell ) )
   allocate ( res ( 4 * ncell ) )
   allocate ( adt ( ncell ) )
+
+  !allocated simply to test op_fetch_data_idx()
+  allocate ( q_part ( 4 * ncell ) )
 
   print *, "Getting data"
   call getSetInfo ( nnode, ncell, nedge, nbedge, cell, edge, ecell, bedge, becell, bound, x, q, qold, res, adt )
@@ -162,10 +165,11 @@ program AIRFOIL
                          & op_arg_dat (p_adt,  -1, OP_ID, 1,"real(8)",  OP_READ),  &
                          & op_arg_gbl (rms, 2, "real(8)", OP_INC))
 
-
-      call op_fetch_data(p_q,q)
-    
     end do ! internal loop
+
+    call op_fetch_data(p_q,q)
+
+    call op_fetch_data_idx(p_q,q_part, 1, ncell)
 
     ncellr = real ( ncell )
     rms(2) = sqrt ( rms(2) / ncellr )

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
@@ -105,7 +105,7 @@ program AIRFOIL
 
   print *, "Declaring OP2 constants"
        
-  call op_dump_to_hdf5("new_grid_out.h5")
+  !call op_dump_to_hdf5("new_grid_out.h5")
   !call op_fetch_data_hdf5_file(p_x, "new_grid_out.h5")
 
   ! start timer
@@ -187,6 +187,7 @@ program AIRFOIL
   end do ! external loop
 
   call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
+  call op_fetch_data(p_q, q)
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
@@ -103,6 +103,7 @@ program AIRFOIL
   call op_decl_dat ( cells, 1, 'real(8)', adt, p_adt, 'p_adt' )
   call op_decl_dat ( cells, 4, 'real(8)', res, p_res, 'p_res' )
 
+
   print *, "Declaring OP2 constants"
        
   !call op_dump_to_hdf5("new_grid_out.h5")
@@ -173,6 +174,8 @@ program AIRFOIL
 
 
 
+      call op_fetch_data(p_q,q)
+    
     end do ! internal loop
 
     ncellr = real ( ncell )
@@ -186,8 +189,6 @@ program AIRFOIL
 
   end do ! external loop
 
-  call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
-  call op_fetch_data(p_q, q)
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
@@ -186,6 +186,7 @@ program AIRFOIL
 
   end do ! external loop
 
+  call op_print_dat_to_txtfile(p_q, "out_grid_seq.dat") !ASCI
   call op_timers ( endTime )
   call op_timing_output ()
   write (*,*), 'Max total runtime =', endTime - startTime,'seconds'

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
@@ -45,7 +45,7 @@ program AIRFOIL
 
   ! arrays used in data
   integer(4), dimension(:), allocatable, target :: ecell, bound, edge, bedge, becell, cell
-  real(8), dimension(:), allocatable, target :: x, q, qold, adt, res
+  real(8), dimension(:), allocatable, target :: x, q, qold, adt, res, q_part
   real(8), dimension(1:2) :: rms
 
   integer(4) :: debugiter, retDebug
@@ -70,6 +70,9 @@ program AIRFOIL
   allocate ( qold ( 4 * ncell ) )
   allocate ( res ( 4 * ncell ) )
   allocate ( adt ( ncell ) )
+
+  !allocated simply to test op_fetch_data_idx()
+  allocate ( q_part ( 4 * ncell ) )
 
   print *, "Getting data"
   call getSetInfo ( nnode, ncell, nedge, nbedge, cell, edge, ecell, bedge, becell, bound, x, q, qold, res, adt )
@@ -173,10 +176,11 @@ program AIRFOIL
                        & op_arg_gbl(rms,2,"real(8)",OP_INC))
 
 
-
-      call op_fetch_data(p_q,q)
-    
     end do ! internal loop
+
+    call op_fetch_data(p_q,q)
+
+    call op_fetch_data_idx(p_q,q_part, 1, ncell)
 
     ncellr = real ( ncell )
     rms(2) = sqrt ( rms(2) / ncellr )

--- a/apps/fortran/airfoil/airfoil_plain/dp/save_soln.inc2
+++ b/apps/fortran/airfoil/airfoil_plain/dp/save_soln.inc2
@@ -8,4 +8,5 @@ SUBROUTINE save_soln_gpu(q,qold)
   DO i = 1, 4
     qold(i) = q(i)
   END DO
+
 END SUBROUTINE

--- a/doc/C++_Users_Guide.tex
+++ b/doc/C++_Users_Guide.tex
@@ -701,10 +701,10 @@ block.}
 \item[data]          pointer to a block of memory of type T -- allocated by the user
 \end{routine}
 
-\subsubsection*{}\addcontentsline{toc}{subsubsection}{op\_fetch\_data\_hdf5}
-\begin{routine} {void op\_fetch\_data\_hdf5(op\_dat dat, T* data, int low, int high)}
+\subsubsection*{}\addcontentsline{toc}{subsubsection}{op\_fetch\_data\_idx}
+\begin{routine} {void op\_fetch\_data\_idx(op\_dat dat, T* data, int low, int high)}
 {Transfers a copy of the op\_dat's data currently held by OP2 to a user allocated block of memory pointed
-to by data pointer of type T. The {\tt low} and {\tt high} integers gives the range of elements to be fetched. Under MPI
+to by data pointer of type T. The {\tt low} and {\tt high} integers gives the range of elements (or indices) to be fetched. Under MPI
 (with hdf5) all the processes will hold the same data block(i.e. after an \texttt{MPI\_Allgather})}
 \item [dat] OP dataset ID -- The op dat whose data is to be fetched from OP2 space to user space
 \item [data] pointer to a block of memory of type T -- allocated by the user

--- a/op2/c/include/op_lib_c.h
+++ b/op2/c/include/op_lib_c.h
@@ -98,7 +98,7 @@ op_dat op_fetch_data_file_char ( op_dat );
 
 void op_upload_all ( );
 
-void op_fetch_data_hdf5_char ( op_dat , char* , int, int);
+void op_fetch_data_idx_char ( op_dat , char* , int, int);
 
 void op_exit (  );
 

--- a/op2/c/include/op_lib_cpp.h
+++ b/op2/c/include/op_lib_cpp.h
@@ -191,9 +191,9 @@ void op_fetch_data ( op_dat dat, T* usr_ptr)
 }
 
 template < class T >
-void op_fetch_data_hdf5(op_dat dat, T* usr_ptr, int low, int high)
+void op_fetch_data_idx (op_dat dat, T* usr_ptr, int low, int high)
 {
-  op_fetch_data_hdf5_char(dat, (char* )usr_ptr, low, high);
+  op_fetch_data_idx_char(dat, (char* )usr_ptr, low, high);
 }
 
 //

--- a/op2/c/src/core/op_lib_core.c
+++ b/op2/c/src/core/op_lib_core.c
@@ -850,7 +850,10 @@ void op_print_dat_to_txtfile_core(op_dat dat, const char* file_name)
   {
     for(int j = 0; j < dat->dim; j++ )
     {
-      if( (strcmp(dat->type,"double") == 0) || (strcmp(dat->type,"double:soa") == 0))
+      if( strcmp(dat->type,"double") == 0 ||
+          strcmp(dat->type,"double:soa") == 0 ||
+          strcmp(dat->type,"double precision") == 0 ||
+          strcmp(dat->type,"real(8)") == 0)
       {
         if(fprintf(fp, "%lf ", ((double *)dat->data)[i*dat->dim+j])<0)
         {
@@ -858,7 +861,10 @@ void op_print_dat_to_txtfile_core(op_dat dat, const char* file_name)
           exit(2);
         }
       }
-      else if((strcmp(dat->type,"float") == 0) || (strcmp(dat->type,"float:soa") == 0))
+      else if(strcmp(dat->type,"float")==0 ||
+            strcmp(dat->type,"float:soa") == 0 ||
+            strcmp(dat->type,"real(4)") == 0 ||
+            strcmp(dat->type,"real") == 0 )
       {
         if(fprintf(fp, "%f ", ((float *)dat->data)[i*dat->dim+j])<0)
         {
@@ -866,7 +872,10 @@ void op_print_dat_to_txtfile_core(op_dat dat, const char* file_name)
           exit(2);
         }
       }
-      else if((strcmp(dat->type,"int") == 0) || (strcmp(dat->type,"int:soa") == 0))
+      else if( strcmp(dat->type,"int")==0 || strcmp(dat->type,"int:soa") == 0 ||
+             strcmp(dat->type,"int(4)") == 0 ||
+             strcmp(dat->type,"integer") == 0 ||
+             strcmp(dat->type,"integer(4)") == 0 )
       {
         if(fprintf(fp, "%d ", ((int *)dat->data)[i*dat->dim+j])<0)
         {

--- a/op2/c/src/cuda/op_cuda_decl.c
+++ b/op2/c/src/cuda/op_cuda_decl.c
@@ -254,7 +254,7 @@ void op_timing_output()
 
 void op_print_dat_to_binfile(op_dat dat, const char *file_name)
 {
-  //need to get data from GPU
+  //need to get data from GPU 
   op_cuda_get_data(dat);
   op_print_dat_to_binfile_core(dat, file_name);
 }
@@ -295,7 +295,7 @@ void op_upload_all ()
 }
 
 void op_fetch_data_char ( op_dat dat, char * usr_ptr )
-{
+{ 
   op_cuda_get_data(dat);
   //need to copy data into memory pointed to by usr_ptr
   memcpy((void *)usr_ptr, (void *)dat->data, dat->set->size*dat->size);

--- a/op2/c/src/cuda/op_cuda_decl.c
+++ b/op2/c/src/cuda/op_cuda_decl.c
@@ -254,7 +254,7 @@ void op_timing_output()
 
 void op_print_dat_to_binfile(op_dat dat, const char *file_name)
 {
-  //need to get data from GPU 
+  //need to get data from GPU
   op_cuda_get_data(dat);
   op_print_dat_to_binfile_core(dat, file_name);
 }
@@ -295,19 +295,19 @@ void op_upload_all ()
 }
 
 void op_fetch_data_char ( op_dat dat, char * usr_ptr )
-{ 
+{
   op_cuda_get_data(dat);
   //need to copy data into memory pointed to by usr_ptr
   memcpy((void *)usr_ptr, (void *)dat->data, dat->set->size*dat->size);
 }
 
 void
-op_fetch_data_hdf5_char ( op_dat dat, char * usr_ptr, int low, int high)
+op_fetch_data_idx_char ( op_dat dat, char * usr_ptr, int low, int high)
 {
   op_cuda_get_data(dat);
   if(low < 0 || high > dat->set->size -1)
   {
-    printf("op_fetch_data_hdf5: Indices not within range of elements held in %s\n",
+    printf("op_fetch_data: Indices not within range of elements held in %s\n",
       dat->name);
     exit(2);
   }

--- a/op2/c/src/mpi/op_mpi_cuda_decl.c
+++ b/op2/c/src/mpi/op_mpi_cuda_decl.c
@@ -457,7 +457,7 @@ op_dat op_fetch_data_file_char(op_dat dat)
   return op_mpi_get_data(dat);
 }
 
-void op_fetch_data_hdf5_char(op_dat dat, char * usr_ptr, int low, int high)
+void op_fetch_data_idx_char(op_dat dat, char * usr_ptr, int low, int high)
 {
   //need to get data from GPU
   op_cuda_get_data(dat);

--- a/op2/c/src/mpi/op_mpi_decl.c
+++ b/op2/c/src/mpi/op_mpi_decl.c
@@ -141,7 +141,7 @@ void op_fetch_data_char(op_dat dat, char* usr_ptr)
   free(temp);
 }
 
-void op_fetch_data_hdf5_char(op_dat dat, char * usr_ptr, int low, int high)
+void op_fetch_data_idx_char(op_dat dat, char * usr_ptr, int low, int high)
 {
   //rearrange data back to original order in mpi
   op_dat temp = op_mpi_get_data(dat);

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -57,6 +57,7 @@
 
 #include <op_mpi_core.h>
 #include <op_hdf5.h>
+#include <H5FDmpio.h>
 
 //
 //MPI Communicator for parallel I/O

--- a/op2/c/src/mpi/op_mpi_util.cpp
+++ b/op2/c/src/mpi/op_mpi_util.cpp
@@ -117,7 +117,7 @@ void gather_data_hdf5(op_dat dat, char* usr_ptr, int low, int high)
 
   if(low < 0 || high > g_size -1)
   {
-    printf("op_fetch_data_hdf5: Indices not within range of elements held in %s\n",
+    printf("op_fetch_data: Indices not within range of elements held in %s\n",
       dat->name);
     MPI_Abort(OP_MPI_IO_WORLD, -1);
   }

--- a/op2/c/src/openmp/op_openmp_decl.c
+++ b/op2/c/src/openmp/op_openmp_decl.c
@@ -84,11 +84,11 @@ op_fetch_data_char ( op_dat dat, char * usr_ptr )
 }
 
 void
-op_fetch_data_hdf5_char ( op_dat dat, char * usr_ptr, int low, int high )
+op_fetch_data_idx_char ( op_dat dat, char * usr_ptr, int low, int high )
 {
   if(low < 0 || high > dat->set->size -1)
   {
-    printf("op_fetch_data_hdf5: Indices not within range of elements held in %s\n",
+    printf("op_fetch_data: Indices not within range of elements held in %s\n",
       dat->name);
     exit(2);
   }

--- a/op2/c/src/sequential/op_seq.c
+++ b/op2/c/src/sequential/op_seq.c
@@ -131,11 +131,11 @@ op_fetch_data_char ( op_dat dat, char * usr_ptr)
 }
 
 void
-op_fetch_data_hdf5_char ( op_dat dat, char * usr_ptr, int low, int high)
+op_fetch_data_idx_char ( op_dat dat, char * usr_ptr, int low, int high)
 {
   if(low < 0 || high > dat->set->size -1)
   {
-    printf("op_fetch_data_hdf5: Indices not within range of elements held in %s\n",
+    printf("op_fetch_data: Indices not within range of elements held in %s\n",
       dat->name);
     exit(2);
   }

--- a/op2/fortran/Makefile
+++ b/op2/fortran/Makefile
@@ -414,3 +414,4 @@ clean:
 	-rm -if $(F_MPI_INC_MOD)/*.mod
 	-rm -if $(F_OP2)/*~
 
+

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -287,13 +287,14 @@ module OP2_Fortran_Declarations
 
     end subroutine
 
-    subroutine op_fetch_data_f ( opdat ) BIND(C,name='op_fetch_data')
+    subroutine op_fetch_data_c ( opdat, data ) BIND(C,name='op_fetch_data_char')
+      use, intrinsic :: ISO_C_BINDING
+      import :: op_dat
 
-      import :: op_dat_core
+      type(op_dat) :: opdat
+      type(c_ptr), value :: data
 
-      type(op_dat_core) :: opdat
-
-    end subroutine op_fetch_data_f
+    end subroutine op_fetch_data_c
 
     subroutine op_timers_core_f ( cpu, et ) BIND(C,name='op_timers_core')
       use, intrinsic :: ISO_C_BINDING
@@ -477,6 +478,11 @@ module OP2_Fortran_Declarations
   interface op_opt_arg_dat
     module procedure op_opt_arg_dat_python
   end interface op_opt_arg_dat
+
+  interface op_fetch_data
+    module procedure op_fetch_data_real_8, op_fetch_data_real_4, &
+    op_fetch_data_integer_4
+  end interface op_fetch_data
 
 contains
 
@@ -1150,5 +1156,32 @@ contains
     call op_print_c (line//C_NULL_CHAR)
 
   end subroutine
+
+  subroutine op_fetch_data_real_8 ( dat, data )
+
+    real(8), dimension(*), target :: data
+    type(op_dat) :: dat
+
+    call op_fetch_data_c ( dat, c_loc (data))
+
+  end subroutine op_fetch_data_real_8
+
+  subroutine op_fetch_data_real_4 ( dat, data )
+
+    real, dimension(*), target :: data
+    type(op_dat) :: dat
+
+    call op_fetch_data_c ( dat, c_loc (data))
+
+  end subroutine op_fetch_data_real_4
+
+  subroutine op_fetch_data_integer_4 ( dat, data )
+
+    integer(4), dimension(*), target :: data
+    type(op_dat) :: dat
+
+    call op_fetch_data_c ( dat, c_loc (data))
+
+  end subroutine op_fetch_data_integer_4
 
 end module OP2_Fortran_Declarations

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -289,9 +289,9 @@ module OP2_Fortran_Declarations
 
     subroutine op_fetch_data_c ( opdat, data ) BIND(C,name='op_fetch_data_char')
       use, intrinsic :: ISO_C_BINDING
-      import :: op_dat
+      import :: op_dat_core
 
-      type(op_dat) :: opdat
+      type(op_dat_core) :: opdat
       type(c_ptr), value :: data
 
     end subroutine op_fetch_data_c
@@ -1162,7 +1162,7 @@ contains
     real(8), dimension(*), target :: data
     type(op_dat) :: dat
 
-    call op_fetch_data_c ( dat, c_loc (data))
+    call op_fetch_data_c ( dat%dataPtr, c_loc (data))
 
   end subroutine op_fetch_data_real_8
 
@@ -1171,7 +1171,7 @@ contains
     real, dimension(*), target :: data
     type(op_dat) :: dat
 
-    call op_fetch_data_c ( dat, c_loc (data))
+    call op_fetch_data_c ( dat%dataPtr, c_loc (data))
 
   end subroutine op_fetch_data_real_4
 
@@ -1180,7 +1180,7 @@ contains
     integer(4), dimension(*), target :: data
     type(op_dat) :: dat
 
-    call op_fetch_data_c ( dat, c_loc (data))
+    call op_fetch_data_c ( dat%dataPtr, c_loc (data))
 
   end subroutine op_fetch_data_integer_4
 

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -423,6 +423,16 @@ module OP2_Fortran_Declarations
 
     end subroutine op_print_dat_to_binfile_c
 
+    subroutine op_print_dat_to_txtfile_c (dat, fileName) BIND(C,name='op_print_dat_to_txtfile')
+      use, intrinsic :: ISO_C_BINDING
+
+      import :: op_dat_core
+
+      type(op_dat_core) :: dat
+      character(len=1,kind=c_char) :: fileName(*)
+
+    end subroutine op_print_dat_to_txtfile_c
+
     logical(kind=c_bool) function isCNullPointer_c (ptr) BIND(C,name='isCNullPointer')
       use, intrinsic :: ISO_C_BINDING
 
@@ -1111,6 +1121,15 @@ contains
     call op_print_dat_to_binfile_c (dat%dataPtr, fileName)
 
   end subroutine op_print_dat_to_binfile
+
+  subroutine op_print_dat_to_txtfile (dat, fileName)
+
+    type(op_dat) :: dat
+    character(len=*) :: fileName
+
+    call op_print_dat_to_txtfile_c (dat%dataPtr, fileName)
+
+  end subroutine op_print_dat_to_txtfile
 
   subroutine op_mpi_rank (rank)
 

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -296,6 +296,17 @@ module OP2_Fortran_Declarations
 
     end subroutine op_fetch_data_c
 
+    subroutine op_fetch_data_idx_c ( opdat, data, low, high) BIND(C,name='op_fetch_data_idx_char')
+      use, intrinsic :: ISO_C_BINDING
+      import :: op_dat_core
+
+      type(op_dat_core) :: opdat
+      type(c_ptr), value :: data
+      integer(kind=c_int), value :: high
+      integer(kind=c_int), value :: low
+
+    end subroutine op_fetch_data_idx_c
+
     subroutine op_timers_core_f ( cpu, et ) BIND(C,name='op_timers_core')
       use, intrinsic :: ISO_C_BINDING
 
@@ -483,6 +494,11 @@ module OP2_Fortran_Declarations
     module procedure op_fetch_data_real_8, op_fetch_data_real_4, &
     op_fetch_data_integer_4
   end interface op_fetch_data
+
+  interface op_fetch_data_idx
+    module procedure op_fetch_data_idx_real_8, op_fetch_data_idx_real_4, &
+    op_fetch_data_idx_integer_4
+  end interface op_fetch_data_idx
 
 contains
 
@@ -1183,5 +1199,38 @@ contains
     call op_fetch_data_c ( dat%dataPtr, c_loc (data))
 
   end subroutine op_fetch_data_integer_4
+
+  subroutine op_fetch_data_idx_real_8 ( dat, data, low, high )
+
+    real(8), dimension(*), target :: data
+    type(op_dat) :: dat
+    integer(kind=c_int), value :: high
+    integer(kind=c_int), value :: low
+
+    call op_fetch_data_idx_c ( dat%dataPtr, c_loc (data), low-1, high-1)
+
+  end subroutine op_fetch_data_idx_real_8
+
+  subroutine op_fetch_data_idx_real_4 ( dat, data, low, high )
+
+    real, dimension(*), target :: data
+    type(op_dat) :: dat
+    integer(kind=c_int), value :: high
+    integer(kind=c_int), value :: low
+
+    call op_fetch_data_idx_c ( dat%dataPtr, c_loc (data), low-1, high-1)
+
+  end subroutine op_fetch_data_idx_real_4
+
+  subroutine op_fetch_data_idx_integer_4 ( dat, data, low, high )
+
+    integer(4), dimension(*), target :: data
+    type(op_dat) :: dat
+    integer(kind=c_int), value :: high
+    integer(kind=c_int), value :: low
+
+    call op_fetch_data_idx_c ( dat%dataPtr, c_loc (data), low-1, high-1)
+
+  end subroutine op_fetch_data_idx_integer_4
 
 end module OP2_Fortran_Declarations

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -29,7 +29,7 @@ echo "**********************************************************************"
 . $CURRENT_DIR/source_intel
 make clean; make
 
-#<<COMMENT1
+##<<COMMENT1
 
 echo " "
 echo " "
@@ -230,7 +230,7 @@ export OMP_NUM_THREADS=20
 ./jac_openmp
 $MPI_INSTALL_PATH/bin/mpirun -np 20 ./jac_mpi
 
-#<<COMMENT1
+##COMMENT1
 ################################################################################
 ################################################################################
 echo " "

--- a/translator/fortran/python/op2_gen_mpivec.py
+++ b/translator/fortran/python/op2_gen_mpivec.py
@@ -323,8 +323,7 @@ def op2_gen_mpivec(master, date, consts, kernels, hydra):
         j = kernel_text[i:].find('(')
         k = para_parse(kernel_text, i+j, '(', ')')
         l = kernel_text[k:].find('END'+'\\s+\\b'+'SUBROUTINE')
-        para = kernel_text[j+1:k].split(',')
-
+        para = kernel_text[j+1:k].split(',') 
         #remove direct vars from para
         para_ind = []
         for i in range(0,nargs):


### PR DESCRIPTION
Adds missing functions to Fortran API 
op_print_dat_to_txtfile() , op_fetch_data()

Additionally change name of op_fetch_data_hdf5 to op_fetch_data_idx as it reflects the function's operation more clearly.