### PR TITLE
Adding command line argument to indicate if the indexing style of the …

### DIFF
--- a/apps/fortran/airfoil/airfoil_hdf5/dp/airfoil_hdf5.F90
+++ b/apps/fortran/airfoil/airfoil_hdf5/dp/airfoil_hdf5.F90
@@ -51,7 +51,6 @@ program AIRFOIL
 
   ! OP initialisation
   call op_init (0)
-  call op_print ("Initialising OP2")
 
   ! declare sets, pointers, datasets and global constants (for now, no new partition info)
   call op_print ("Declaring OP2 sets")

--- a/apps/fortran/airfoil/airfoil_hdf5/dp/airfoil_hdf5_op.F90
+++ b/apps/fortran/airfoil/airfoil_hdf5/dp/airfoil_hdf5_op.F90
@@ -60,7 +60,6 @@ program AIRFOIL
 
   ! OP initialisation
   call op_init (0)
-  call op_print ("Initialising OP2")
 
   ! declare sets, pointers, datasets and global constants (for now, no new partition info)
   call op_print ("Declaring OP2 sets")

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil.F90
@@ -70,7 +70,6 @@ program AIRFOIL
   call getSetInfo ( nnode, ncell, nedge, nbedge, cell, edge, ecell, bedge, becell, bound, x, q, qold, res, adt )
 
   ! OP initialisation
-  print *, "Initialising OP2"
   call op_init (0)
 
   print *, "Initialising constants"

--- a/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
+++ b/apps/fortran/airfoil/airfoil_plain/dp/airfoil_op.F90
@@ -79,7 +79,6 @@ program AIRFOIL
   call getSetInfo ( nnode, ncell, nedge, nbedge, cell, edge, ecell, bedge, becell, bound, x, q, qold, res, adt )
 
   ! OP initialisation
-  print *, "Initialising OP2"
   call op_init (0)
 
   print *, "Initialising constants"

--- a/op2/c/include/op_lib_c.h
+++ b/op2/c/include/op_lib_c.h
@@ -105,10 +105,6 @@ void op_exit (  );
 
 void op_timing_output();
 
-void op_printf(const char* format, ...);
-
-void op_print(const char* line);
-
 void op_rank(int* rank);
 
 void op_timers( double *cpu, double *et );

--- a/op2/c/include/op_lib_core.h
+++ b/op2/c/include/op_lib_core.h
@@ -80,6 +80,7 @@ extern int OP_diags;
 extern int OP_cache_line_size;
 extern double OP_hybrid_balance;
 extern int OP_hybrid_gpu;
+extern int OP_maps_base_index;
 
 /*
  * enum list for op_par_loop
@@ -242,6 +243,10 @@ op_dat op_decl_dat_temp_core ( op_set, int, char const*, int, char *, char const
 int op_free_dat_temp_core ( op_dat );
 
 void op_decl_const_core ( int dim, char const * type, int typeSize, char * data, char const * name );
+
+void op_printf(const char* format, ...);
+
+void op_print(const char* line);
 
 void op_err_print ( const char * error_string, int m, const char * name );
 

--- a/op2/c/include/op_mpi_core.h
+++ b/op2/c/include/op_mpi_core.h
@@ -214,7 +214,7 @@ typedef struct {
   int nprocs;
   int *proclist;
   int gbl_offset;
-  op_dat coords; 
+  op_dat coords;
   op_dat mark;
   int max_dat_size;
   int num_my_ifaces;

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -252,16 +252,13 @@ module OP2_Fortran_Declarations
       character(len=1, kind=C_CHAR) :: argv
     end subroutine op_set_args_c
 
-    subroutine op_mpi_init_c ( argc, argv, diags, global, local ) BIND(C,name='op_mpi_init')
-
+     subroutine op_mpi_init_c ( argc, argv, diags, global, local ) BIND(C,name='op_mpi_init')
       use, intrinsic :: ISO_C_BINDING
-
       integer(kind=c_int), intent(in), value :: argc
       type(c_ptr), intent(in)                :: argv
       integer(kind=c_int), intent(in), value :: diags
       integer(kind=c_int), intent(in), value :: global
       integer(kind=c_int), intent(in), value :: local
-
     end subroutine op_mpi_init_c
 
     subroutine op_exit_c (  ) BIND(C,name='op_exit')
@@ -641,6 +638,12 @@ module OP2_Fortran_Declarations
 
     end subroutine op_theta_init_c
 
+    subroutine set_maps_base_c (base) BIND(C,name='set_maps_base')
+      use ISO_C_BINDING
+      integer(c_int), value :: base
+    end subroutine set_maps_base_c
+
+
   end interface
 
   ! the two numbers at the end of the name indicate the size of the type (e.g. real(8))
@@ -716,6 +719,9 @@ contains
 
     OP_ID%mapPtr => idPtr
     OP_GBL%mapPtr => gblPtr
+    call set_maps_base_c(1)
+
+    call op_init_c ( 0, C_NULL_PTR, diags )
 
     !Get the command line arguments - needs to be handled using Fortrn
     argc = command_argument_count()
@@ -724,7 +730,6 @@ contains
       call op_set_args_c (argc, temp) !special function to set args
     end do
 
-    call op_init_c ( 0, C_NULL_PTR, diags )
 
   end subroutine op_init
 

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -770,6 +770,7 @@ contains
 
     OP_ID%mapPtr => idPtr
     OP_GBL%mapPtr => gblPtr
+    call set_maps_base_c(1)
 
     call op_mpi_init_c ( argc, C_NULL_PTR, diags, global, local )
 

--- a/op2/fortran/src/op2_for_declarations.F90
+++ b/op2/fortran/src/op2_for_declarations.F90
@@ -744,6 +744,8 @@ contains
     integer(c_int) :: argc = 0
 
     integer(4) :: rank2, ierr
+    integer :: i
+    character(kind=c_char,len=64)           :: temp
 
 #ifdef OP2_WITH_CUDAFOR
     integer(4) :: setDevReturnVal = -1
@@ -770,6 +772,13 @@ contains
     OP_GBL%mapPtr => gblPtr
 
     call op_mpi_init_c ( argc, C_NULL_PTR, diags, global, local )
+
+    !Get the command line arguments - needs to be handled using Fortrn
+    argc = command_argument_count()
+    do i = 1, argc
+      call get_command_argument(i, temp)
+      call op_set_args_c (argc, temp) !special function to set args
+    end do
 
   end subroutine op_mpi_init
 

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -232,6 +232,7 @@ export OMP_NUM_THREADS=20
 ./jac_openmp
 $MPI_INSTALL_PATH/bin/mpirun -np 20 ./jac_mpi
 
+#COMMENT1
 
 ################################################################################
 ################################################################################
@@ -276,10 +277,11 @@ echo "=======================> Running Airfoil Fortran Plain DP built with Intel
 cd $OP2_APPS_DIR/fortran/airfoil/airfoil_plain/dp
 pwd
 export PART_SIZE_ENV=128
-./airfoil_seq
-./airfoil_vec
+./airfoil_seq OP_MAPS_BASE_INDEX=0
+./airfoil_vec OP_MAPS_BASE_INDEX=0
 export OMP_NUM_THREADS=20
-./airfoil_openmp #_$PART_SIZE_ENV
+./airfoil_openmp  OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 
 
 
@@ -289,17 +291,20 @@ echo "=======================> Running Airfoil Fortran HDF5 DP built with Intel 
 cd $OP2_APPS_DIR/fortran/airfoil/airfoil_hdf5/dp
 pwd
 export PART_SIZE_ENV=128
-./airfoil_hdf5_seq
-#./airfoil_hdf5_vec
-./airfoil_hdf5_openmp #_$PART_SIZE_ENV
+./airfoil_hdf5_seq OP_MAPS_BASE_INDEX=0
+#./airfoil_hdf5_vec OP_MAPS_BASE_INDEX=0
+./airfoil_hdf5_openmp OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 export OMP_NUM_THREADS=1
-$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi
-$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi_vec
-$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi_genseq
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi OP_MAPS_BASE_INDEX=0
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi_vec OP_MAPS_BASE_INDEX=0
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi_genseq OP_MAPS_BASE_INDEX=0
 export OMP_NUM_THREADS=20
-./airfoil_hdf5_mpi_openmp #_$PART_SIZE_ENV
+./airfoil_hdf5_mpi_openmp OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 export OMP_NUM_THREADS=2
-$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_hdf5_mpi #_openmp_$PART_SIZE_ENV
+$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_hdf5_mpi OP_MAPS_BASE_INDEX=0
+#_openmp_$PART_SIZE_ENV
 
 #COMMENT1
 ###################################################################################
@@ -345,10 +350,11 @@ echo "=======================> Running Airfoil Fortran Plain DP built with PGI C
 cd $OP2_APPS_DIR/fortran/airfoil/airfoil_plain/dp
 pwd
 export PART_SIZE_ENV=128
-./airfoil_seq
-./airfoil_cuda
+./airfoil_seq OP_MAPS_BASE_INDEX=0
+./airfoil_cuda OP_MAPS_BASE_INDEX=0
 export OMP_NUM_THREADS=20
-./airfoil_openmp #_$PART_SIZE_ENV
+./airfoil_openmp OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 
 echo " "
 echo " "
@@ -356,17 +362,20 @@ echo "=======================> Running Airfoil Fortran HDF5 DP built with PGI Co
 cd $OP2_APPS_DIR/fortran/airfoil/airfoil_hdf5/dp
 pwd
 export PART_SIZE_ENV=128
-./airfoil_hdf5_seq
-./airfoil_hdf5_cuda
+./airfoil_hdf5_seq OP_MAPS_BASE_INDEX=0
+./airfoil_hdf5_cuda OP_MAPS_BASE_INDEX=0
 export OMP_NUM_THREADS=20
-./airfoil_hdf5_openmp #_$PART_SIZE_ENV
+./airfoil_hdf5_openmp OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 export OMP_NUM_THREADS=1
-$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi
-./airfoil_hdf5_mpi_cuda OP_PART_SIZE=128 OP_BLOCK_SIZE=192
-$MPI_INSTALL_PATH/bin/mpirun -np 2 ./airfoil_hdf5_mpi_cuda OP_PART_SIZE=128 OP_BLOCK_SIZE=192
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./airfoil_hdf5_mpi OP_MAPS_BASE_INDEX=0
+./airfoil_hdf5_mpi_cuda OP_PART_SIZE=128 OP_BLOCK_SIZE=192 OP_MAPS_BASE_INDEX=0
+$MPI_INSTALL_PATH/bin/mpirun -np 2 ./airfoil_hdf5_mpi_cuda OP_PART_SIZE=128 OP_BLOCK_SIZE=192 OP_MAPS_BASE_INDEX=0
 export OMP_NUM_THREADS=20
-./airfoil_hdf5_mpi_openmp #_$PART_SIZE_ENV
+./airfoil_hdf5_mpi_openmp OP_MAPS_BASE_INDEX=0 
+#_$PART_SIZE_ENV
 export OMP_NUM_THREADS=2
-$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_hdf5_mpi_openmp #_$PART_SIZE_ENV
+$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_hdf5_mpi_openmp OP_MAPS_BASE_INDEX=0
+#_$PART_SIZE_ENV
 
 


### PR DESCRIPTION
…application should be C or Fortran style.

This pull request is to fix a long-standing issue in the Fortran API and libraries needing mapping tables based on C style indexing (i.e. array indices starting at 0). What a application developer using the Fortran API will assume by default is that all indexing is 1 based (i.e. Fortran style indexing). However OP2's core routines are in C/C++ and have always assumed 0 based indexing. This has caused some confusion to some of our users.

With this pull request we are making the following changes:
1. We assume that an application written using the Fortran API will by default assume Fortran style indexing
2. We assume that an application written using the C/C++ API will by default assume C/C++ style indexing
3. By using the OP_MAPS_BASE_INDEX=0 or OP_MAPS_BASE_INDEX=1 runtime arguments you can override the default indexing style for the mapping tables. 

As such assume that a developer has a mesh's mapping tables using C style indexing, but needs to use this mapping tables in an application written using the Fortran API. Then specifying OP_MAPS_BASE_INDEX=0 will allow the application to read this mapping table without issues.  

Currently the airfoil application written in Fortan under apps/fortran/airfoil needs to use mappings based on C style indexing. As such after this pull request you should run the application as : 

./airfoil_seq OP_MAPS_BASE_INDEX=0

