### PR TITLE
Fix/codeformatting2

### DIFF
--- a/op2/c/include/op_cuda_rt_support.h
+++ b/op2/c/include/op_cuda_rt_support.h
@@ -41,8 +41,8 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
-#include <device_launch_parameters.h>
 #include <device_functions.h>
+#include <device_launch_parameters.h>
 
 #include <op_lib_core.h>
 #include <op_rt_support.h>
@@ -58,37 +58,35 @@ extern "C" {
 /*
  * Global variables actually defined in the corresponding c file
  */
-extern char * OP_consts_h,
-            * OP_consts_d,
-            * OP_reduct_h,
-            * OP_reduct_d;
+extern char *OP_consts_h, *OP_consts_d, *OP_reduct_h, *OP_reduct_d;
 
-extern void __syncthreads (  );
+extern void __syncthreads();
 
 /*
  * personal stripped-down version of cutil_inline.h
  */
 
-#define cutilSafeCall(err) __cudaSafeCall(err,__FILE__,__LINE__)
-#define cutilCheckMsg(msg) __cutilCheckMsg(msg,__FILE__,__LINE__)
+#define cutilSafeCall(err) __cudaSafeCall(err, __FILE__, __LINE__)
+#define cutilCheckMsg(msg) __cutilCheckMsg(msg, __FILE__, __LINE__)
 
-void __cudaSafeCall( cudaError_t err, const char * file, const int line );
+void __cudaSafeCall(cudaError_t err, const char *file, const int line);
 
-void __cutilCheckMsg( const char * errorMessage, const char * file, const int line );
+void __cutilCheckMsg(const char *errorMessage, const char *file,
+                     const int line);
 
-void cutilDeviceInit( int argc, char ** argv);
+void cutilDeviceInit(int argc, char **argv);
 
-void cutilDeviceInit_mpi( int argc, char ** argv, int mpi_rank);
+void cutilDeviceInit_mpi(int argc, char **argv, int mpi_rank);
 
 /*
  * routines to move arrays to/from GPU device
  */
 
-void op_mvHostToDevice ( void ** map, int size );
+void op_mvHostToDevice(void **map, int size);
 
-void op_cpHostToDevice ( void ** data_d, void ** data_h, int size );
+void op_cpHostToDevice(void **data_d, void **data_h, int size);
 
-void op_cuda_get_data ( op_dat dat );
+void op_cuda_get_data(op_dat dat);
 
 /*
  * Plan interface for generated code: the implementation changes depending
@@ -99,35 +97,35 @@ void op_cuda_get_data ( op_dat dat );
  * op_rt_support.h header file only declares the low-level functions
  * (e.g. op_plan_core)
  */
-op_plan * op_plan_get ( char const * name, op_set set, int part_size,
-                        int nargs, op_arg * args, int ninds, int * inds );
+op_plan *op_plan_get(char const *name, op_set set, int part_size, int nargs,
+                     op_arg *args, int ninds, int *inds);
 
-op_plan * op_plan_get_stage ( char const * name, op_set set, int part_size,
-                        int nargs, op_arg * args, int ninds, int * inds, int staging );
+op_plan *op_plan_get_stage(char const *name, op_set set, int part_size,
+                           int nargs, op_arg *args, int ninds, int *inds,
+                           int staging);
 
-void op_cuda_exit (  );
+void op_cuda_exit();
 
 /*
  * routines to resize constant/reduct arrays, if necessary
  */
 
-void reallocConstArrays ( int consts_bytes );
+void reallocConstArrays(int consts_bytes);
 
-void reallocReductArrays ( int reduct_bytes );
+void reallocReductArrays(int reduct_bytes);
 
 /*
  * routines to move constant/reduct arrays
  */
 
-void mvConstArraysToDevice ( int consts_bytes );
+void mvConstArraysToDevice(int consts_bytes);
 
-void mvReductArraysToDevice ( int reduct_bytes );
+void mvReductArraysToDevice(int reduct_bytes);
 
-void mvReductArraysToHost ( int reduct_bytes );
+void mvReductArraysToHost(int reduct_bytes);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __OP_CUDA_RT_SUPPORT_H */
-

--- a/op2/c/include/op_hdf5.h
+++ b/op2/c/include/op_hdf5.h
@@ -46,15 +46,17 @@ extern "C" {
 #endif
 
 op_set op_decl_set_hdf5(char const *file, char const *name);
-op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file, char const *name);
-op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file, char const *name);
+op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
+                        char const *name);
+op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
+                        char const *name);
 
-void op_get_const_hdf5(char const *name, int dim, char const *type, char* const_data,
-  char const *file_name);
+void op_get_const_hdf5(char const *name, int dim, char const *type,
+                       char *const_data, char const *file_name);
 
-void op_dump_to_hdf5(char const * file_name);
-void op_write_const_hdf5(char const *name, int dim, char const *type, char* const_data,
-  char const *file_name);
+void op_dump_to_hdf5(char const *file_name);
+void op_write_const_hdf5(char const *name, int dim, char const *type,
+                         char *const_data, char const *file_name);
 
 void op_fetch_data_hdf5_file(op_dat dat, char const *file_name);
 
@@ -63,4 +65,3 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name);
 #endif
 
 #endif /* __OP_HDF5_H */
-

--- a/op2/c/include/op_lib_c.h
+++ b/op2/c/include/op_lib_c.h
@@ -44,7 +44,7 @@
 
 /* identity mapping and global identifier */
 
-#define OP_ID  (op_map) NULL
+#define OP_ID (op_map) NULL
 #define OP_GBL (op_map) NULL
 
 /*
@@ -53,62 +53,60 @@
 
 extern int OP_diags, OP_part_size, OP_block_size, OP_gpu_direct;
 
-extern int OP_set_index, OP_set_max,
-           OP_map_index, OP_map_max,
-           OP_dat_index,
-           OP_plan_index, OP_plan_max,
-           OP_kern_max, OP_kern_curr;
+extern int OP_set_index, OP_set_max, OP_map_index, OP_map_max, OP_dat_index,
+    OP_plan_index, OP_plan_max, OP_kern_max, OP_kern_curr;
 
-extern op_set * OP_set_list;
-extern op_map * OP_map_list;
+extern op_set *OP_set_list;
+extern op_map *OP_map_list;
 extern Double_linked_list OP_dat_list;
-extern op_kernel * OP_kernels;
+extern op_kernel *OP_kernels;
 extern double OP_plan_time;
 extern int OP_auto_soa;
 
 /*
- * declaration of C routines wrapping lower layer implementations (e.g. CUDA, reference, etc..)
+ * declaration of C routines wrapping lower layer implementations (e.g. CUDA,
+ * reference, etc..)
  */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void op_init ( int, char **, int);
-void op_init_soa ( int, char **, int, int);
+void op_init(int, char **, int);
+void op_init_soa(int, char **, int, int);
 
-op_set op_decl_set ( int, char const * );
+op_set op_decl_set(int, char const *);
 
-op_map op_decl_map ( op_set, op_set, int, int *, char const * );
+op_map op_decl_map(op_set, op_set, int, int *, char const *);
 
-op_dat op_decl_dat_char ( op_set, int, char const *, int, char *, char const * );
+op_dat op_decl_dat_char(op_set, int, char const *, int, char *, char const *);
 
-op_dat op_decl_dat_temp_char ( op_set, int, char const *, int, char const * );
+op_dat op_decl_dat_temp_char(op_set, int, char const *, int, char const *);
 
-int op_free_dat_temp_char ( op_dat dat );
+int op_free_dat_temp_char(op_dat dat);
 
-void op_decl_const_char ( int, char const *, int, char *, char const * );
+void op_decl_const_char(int, char const *, int, char *, char const *);
 
-op_arg op_arg_dat ( op_dat, int, op_map, int, char const *, op_access );
+op_arg op_arg_dat(op_dat, int, op_map, int, char const *, op_access);
 
-op_arg op_opt_arg_dat ( int, op_dat, int, op_map, int, char const *, op_access );
+op_arg op_opt_arg_dat(int, op_dat, int, op_map, int, char const *, op_access);
 
-op_arg op_arg_gbl_char ( char * , int, const char*, int, op_access);
+op_arg op_arg_gbl_char(char *, int, const char *, int, op_access);
 
-void op_fetch_data_char ( op_dat , char* );
-op_dat op_fetch_data_file_char ( op_dat );
+void op_fetch_data_char(op_dat, char *);
+op_dat op_fetch_data_file_char(op_dat);
 
-void op_upload_all ( );
+void op_upload_all();
 
-void op_fetch_data_idx_char ( op_dat , char* , int, int);
+void op_fetch_data_idx_char(op_dat, char *, int, int);
 
-void op_exit (  );
+void op_exit();
 
 void op_timing_output();
 
-void op_rank(int* rank);
+void op_rank(int *rank);
 
-void op_timers( double *cpu, double *et );
+void op_timers(double *cpu, double *et);
 
 void op_print_dat_to_binfile(op_dat dat, const char *file_name);
 

--- a/op2/c/include/op_lib_core.h
+++ b/op2/c/include/op_lib_core.h
@@ -40,14 +40,14 @@
  * OP2 libraries
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <strings.h>
 #include <math.h>
 #include <stdarg.h>
-#include <sys/queue.h> //contains double linked list implementation
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/queue.h> //contains double linked list implementation
 
 #ifndef OP2_ALIGNMENT
 #define OP2_ALIGNMENT 64
@@ -102,118 +102,112 @@ extern int OP_maps_base_index;
 #define OP_STAGE_PERMUTE 3
 #define OP_COLOR2 4
 
-typedef int op_access; //holds OP_READ, OP_WRITE, OP_RW, OP_INC, OP_MIN, OP_MAX
+typedef int op_access; // holds OP_READ, OP_WRITE, OP_RW, OP_INC, OP_MIN, OP_MAX
 typedef int op_arg_type; // holds OP_ARG_GBL, OP_ARG_DAT
 
 /*
  * structures
  */
 
-typedef struct
-{
-  int         index;        /* index */
-  int         size;         /* number of elements in set */
-  char const *name;         /* name of set */
-// for MPI support
-  int         core_size;      /* number of core elements in an mpi process*/
-  int         exec_size;    /* number of additional imported elements to be executed */
-  int         nonexec_size; /* number of additional imported elements that are not executed */
+typedef struct {
+  int index;        /* index */
+  int size;         /* number of elements in set */
+  char const *name; /* name of set */
+                    // for MPI support
+  int core_size;    /* number of core elements in an mpi process*/
+  int exec_size;    /* number of additional imported elements to be executed */
+  int nonexec_size; /* number of additional imported elements that are not
+                       executed */
 } op_set_core;
 
-typedef op_set_core * op_set;
+typedef op_set_core *op_set;
 
-typedef struct
-{
-  int         index;  /* index */
-  op_set      from,   /* set pointed from */
-              to;     /* set pointed to */
-  int         dim,    /* dimension of pointer */
-             *map;    /* array defining pointer */
-  int        *map_d;  /* array on device */
-  char const *name;   /* name of pointer */
-  int         user_managed; /* indicates whether the user is managing memory */
+typedef struct {
+  int index;        /* index */
+  op_set from,      /* set pointed from */
+      to;           /* set pointed to */
+  int dim,          /* dimension of pointer */
+      *map;         /* array defining pointer */
+  int *map_d;       /* array on device */
+  char const *name; /* name of pointer */
+  int user_managed; /* indicates whether the user is managing memory */
 } op_map_core;
 
-typedef op_map_core * op_map;
+typedef op_map_core *op_map;
 
-typedef struct
-{
-  int         index;  /* index */
-  op_set      set;    /* set on which data is defined */
-  int         dim,    /* dimension of data */
-              size;   /* size of each element in dataset */
-  char       *data,   /* data on host */
-             *data_d; /* data on device (GPU) */
-  char const *type,   /* datatype */
-             *name;   /* name of dataset */
-  char*       buffer_d; /* buffer for MPI halo sends on the devidce */
-  char*       buffer_d_r; /* buffer for MPI halo receives on the devidce */
-  int         dirtybit; /* flag to indicate MPI halo exchange is needed*/
-  int         dirty_hd; /* flag to indicate dirty status on host and device */
-  int         user_managed; /* indicates whether the user is managing memory */
-  void*       mpi_buffer; /* ponter to hold the mpi buffer struct for the op_dat*/
+typedef struct {
+  int index;        /* index */
+  op_set set;       /* set on which data is defined */
+  int dim,          /* dimension of data */
+      size;         /* size of each element in dataset */
+  char *data,       /* data on host */
+      *data_d;      /* data on device (GPU) */
+  char const *type, /* datatype */
+      *name;        /* name of dataset */
+  char *buffer_d;   /* buffer for MPI halo sends on the devidce */
+  char *buffer_d_r; /* buffer for MPI halo receives on the devidce */
+  int dirtybit;     /* flag to indicate MPI halo exchange is needed*/
+  int dirty_hd;     /* flag to indicate dirty status on host and device */
+  int user_managed; /* indicates whether the user is managing memory */
+  void *mpi_buffer; /* ponter to hold the mpi buffer struct for the op_dat*/
 } op_dat_core;
 
-typedef op_dat_core * op_dat;
+typedef op_dat_core *op_dat;
 
-typedef struct
-{
-  int         index;  /* index */
-  op_dat      dat;    /* dataset */
-  op_map      map;    /* indirect mapping */
-  int         dim,    /* dimension of data */
-              idx,
-              size;   /* size (for sequential execution) */
-  char       *data,   /* data on host */
-             *data_d; /* data on device (for CUDA execution) */
-  int        *map_data,   /* data on host */
-             *map_data_d; /* data on device (for CUDA execution) */
-  char const *type;   /* datatype */
-  op_access   acc;
+typedef struct {
+  int index;        /* index */
+  op_dat dat;       /* dataset */
+  op_map map;       /* indirect mapping */
+  int dim,          /* dimension of data */
+      idx, size;    /* size (for sequential execution) */
+  char *data,       /* data on host */
+      *data_d;      /* data on device (for CUDA execution) */
+  int *map_data,    /* data on host */
+      *map_data_d;  /* data on device (for CUDA execution) */
+  char const *type; /* datatype */
+  op_access acc;
   op_arg_type argtype;
-  int         sent;   /* flag to indicate if this argument has
-                         data in flight under non-blocking MPI comms*/
-  int         opt;    /* flag to indicate if this argument is in use */
+  int sent; /* flag to indicate if this argument has
+               data in flight under non-blocking MPI comms*/
+  int opt;  /* flag to indicate if this argument is in use */
 } op_arg;
 
-
-typedef struct
-{
-  char const *name;     /* name of kernel function */
-  int         count;    /* number of times called */
-  float       time;     /* total execution time */
-  float       plan_time;/* time spent in op_plan_get */
-  float       transfer; /* bytes of data transfer (used) */
-  float       transfer2;/* bytes of data transfer (total) */
-  float       mpi_time; /* time spent in MPI calls */
+typedef struct {
+  char const *name; /* name of kernel function */
+  int count;        /* number of times called */
+  float time;       /* total execution time */
+  float plan_time;  /* time spent in op_plan_get */
+  float transfer;   /* bytes of data transfer (used) */
+  float transfer2;  /* bytes of data transfer (total) */
+  float mpi_time;   /* time spent in MPI calls */
 } op_kernel;
 
-
-//struct definition for a double linked list entry to hold an op_dat
-struct op_dat_entry_core{
+// struct definition for a double linked list entry to hold an op_dat
+struct op_dat_entry_core {
   op_dat dat;
-  TAILQ_ENTRY(op_dat_entry_core) entries; /*holds pointers to next and
-                                          previous entries in the list*/
+  TAILQ_ENTRY(op_dat_entry_core)
+  entries; /*holds pointers to next and
+           previous entries in the list*/
 };
 
 typedef struct op_dat_entry_core op_dat_entry;
 
-typedef TAILQ_HEAD(, op_dat_entry_core)  Double_linked_list;
-
+typedef TAILQ_HEAD(, op_dat_entry_core) Double_linked_list;
 
 /*
  * min / max definitions
  */
 
 #ifndef MIN
-#define MIN(a,b) ((a<b) ? (a) : (b))
+#define MIN(a, b) ((a < b) ? (a) : (b))
 #endif
 #ifndef MAX
-#define MAX(a,b) ((a>b) ? (a) : (b))
+#define MAX(a, b) ((a > b) ? (a) : (b))
 #endif
 
 /*
- * alignment macro based on example on page 50 of CUDA Programming Guide version 3.0
+ * alignment macro based on example on page 50 of CUDA Programming Guide version
+ * 3.0
  * rounds up to nearest multiple of 16 bytes
  */
 
@@ -228,51 +222,55 @@ extern "C" {
  * Core lib function prototypes
 *******************************************************************************/
 
-void op_init_core ( int, char **, int );
+void op_init_core(int, char **, int);
 
-void op_exit_core ( void );
+void op_exit_core(void);
 
-op_set op_decl_set_core ( int, char const * );
+op_set op_decl_set_core(int, char const *);
 
-op_map op_decl_map_core ( op_set, op_set, int, int *, char const * );
+op_map op_decl_map_core(op_set, op_set, int, int *, char const *);
 
-op_dat op_decl_dat_core ( op_set, int, char const *, int, char *, char const * );
+op_dat op_decl_dat_core(op_set, int, char const *, int, char *, char const *);
 
-op_dat op_decl_dat_temp_core ( op_set, int, char const*, int, char *, char const * );
+op_dat op_decl_dat_temp_core(op_set, int, char const *, int, char *,
+                             char const *);
 
-int op_free_dat_temp_core ( op_dat );
+int op_free_dat_temp_core(op_dat);
 
-void op_decl_const_core ( int dim, char const * type, int typeSize, char * data, char const * name );
+void op_decl_const_core(int dim, char const *type, int typeSize, char *data,
+                        char const *name);
 
-void op_printf(const char* format, ...);
+void op_printf(const char *format, ...);
 
-void op_print(const char* line);
+void op_print(const char *line);
 
-void op_err_print ( const char * error_string, int m, const char * name );
+void op_err_print(const char *error_string, int m, const char *name);
 
-void op_arg_check ( op_set, int, op_arg, int *, char const * );
+void op_arg_check(op_set, int, op_arg, int *, char const *);
 
-op_arg op_arg_dat_core ( op_dat dat, int idx, op_map map, int dim, const char * typ, op_access acc );
+op_arg op_arg_dat_core(op_dat dat, int idx, op_map map, int dim,
+                       const char *typ, op_access acc);
 
-op_arg op_opt_arg_dat_core ( int opt, op_dat dat, int idx, op_map map, int dim, const char * typ, op_access acc );
+op_arg op_opt_arg_dat_core(int opt, op_dat dat, int idx, op_map map, int dim,
+                           const char *typ, op_access acc);
 
-op_arg op_arg_gbl_core ( char *, int, const char *, int, op_access );
+op_arg op_arg_gbl_core(char *, int, const char *, int, op_access);
 
-void op_diagnostic_output ( void );
+void op_diagnostic_output(void);
 
-void op_timing_output_core ( void );
+void op_timing_output_core(void);
 
-void op_timing_output_2_file ( const char * );
+void op_timing_output_2_file(const char *);
 
-void op_timing_realloc ( int );
+void op_timing_realloc(int);
 
-void op_timers_core( double *cpu, double *et );
+void op_timers_core(double *cpu, double *et);
 
-void op_dump_dat ( op_dat data );
+void op_dump_dat(op_dat data);
 
 void op_print_dat_to_binfile_core(op_dat dat, const char *file_name);
 
-void op_print_dat_to_txtfile_core(op_dat dat, const char* file_name);
+void op_print_dat_to_txtfile_core(op_dat dat, const char *file_name);
 
 void op_compute_moment(double t, double *first, double *second);
 
@@ -280,7 +278,7 @@ int op_size_of_set(const char *);
 
 int op_get_size(op_set set);
 
-void check_map(char const *name, op_set from, op_set to, int dim, int* map);
+void check_map(char const *name, op_set from, op_set to, int dim, int *map);
 
 /*******************************************************************************
 * Core MPI lib function prototypes
@@ -294,30 +292,29 @@ void op_mpi_set_dirtybit(int nargs, op_arg *args);
 
 void op_mpi_set_dirtybit_cuda(int nargs, op_arg *args);
 
-void op_mpi_wait_all(int nargs, op_arg* args);
+void op_mpi_wait_all(int nargs, op_arg *args);
 
-void op_mpi_wait_all_cuda(int nargs, op_arg* args);
+void op_mpi_wait_all_cuda(int nargs, op_arg *args);
 
-void op_mpi_reset_halos(int nargs, op_arg* args);
+void op_mpi_reset_halos(int nargs, op_arg *args);
 
-void op_mpi_reduce_combined(op_arg* args, int nargs);
+void op_mpi_reduce_combined(op_arg *args, int nargs);
 
-void op_mpi_reduce_float(op_arg *args, float* data);
+void op_mpi_reduce_float(op_arg *args, float *data);
 
-void op_mpi_reduce_double(op_arg *args, double* data);
+void op_mpi_reduce_double(op_arg *args, double *data);
 
-void op_mpi_reduce_int(op_arg *args, int* data);
+void op_mpi_reduce_int(op_arg *args, int *data);
 
-void op_mpi_reduce_bool(op_arg* args, bool* data);
+void op_mpi_reduce_bool(op_arg *args, bool *data);
 
 void op_mpi_barrier();
 
 /*******************************************************************************
 * Toplevel partitioning selection function - also triggers halo creation
 *******************************************************************************/
-void op_partition(const char* lib_name, const char* lib_routine,
-  op_set prime_set, op_map prime_map, op_dat coords );
-
+void op_partition(const char *lib_name, const char *lib_routine,
+                  op_set prime_set, op_map prime_map, op_dat coords);
 
 /*******************************************************************************
 * Other partitioning related routine prototypes
@@ -325,33 +322,32 @@ void op_partition(const char* lib_name, const char* lib_routine,
 
 void op_partition_destroy();
 
-void *op_mpi_perf_time(const char* name, double time);
+void *op_mpi_perf_time(const char *name, double time);
 #ifdef COMM_PERF
 void op_mpi_perf_comms(void *k_i, int nargs, op_arg *args);
 #endif
 
 void op_renumber(op_map base);
 
-
 /*******************************************************************************
 * Utility function to compare two op_sets and return 1 if they are identical
 *******************************************************************************/
 int compare_sets(op_set set1, op_set set2);
-op_dat search_dat(op_set set, int dim, char const * type, int size, char const * name);
+op_dat search_dat(op_set set, int dim, char const *type, int size,
+                  char const *name);
 
 int op_is_root();
 
 /*******************************************************************************
 * Memory allocation functions
 *******************************************************************************/
-void* op_malloc (size_t size);
-void* op_realloc (void *ptr, size_t size);
-void  op_free (void *ptr);
-void* op_calloc (size_t num, size_t size);
+void *op_malloc(size_t size);
+void *op_realloc(void *ptr, size_t size);
+void op_free(void *ptr);
+void *op_calloc(size_t num, size_t size);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __OP_LIB_CORE_H */
-

--- a/op2/c/include/op_lib_cpp.h
+++ b/op2/c/include/op_lib_cpp.h
@@ -43,8 +43,8 @@
  * include core definitions and C declarations of op2 user-level routines
  */
 
-#include <op_lib_core.h>
 #include <op_lib_c.h>
+#include <op_lib_core.h>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -54,26 +54,33 @@
  * run-time type-checking routines
  */
 
-inline int type_error (const double * a, const char *type ) {
-  (void)a; return (strcmp ( type, "double" ) && strcmp ( type, "double:soa" ));
+inline int type_error(const double *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "double") && strcmp(type, "double:soa"));
 }
-inline int type_error (const float  * a, const char *type ) {
-  (void)a; return (strcmp ( type, "float" ) && strcmp ( type, "float:soa" ));
+inline int type_error(const float *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "float") && strcmp(type, "float:soa"));
 }
-inline int type_error (const int    * a, const char *type ) {
-  (void)a; return (strcmp ( type, "int"   ) && strcmp ( type, "int:soa"   ));
+inline int type_error(const int *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "int") && strcmp(type, "int:soa"));
 }
-inline int type_error (const uint   * a, const char *type ) {
-  (void)a; return (strcmp ( type, "uint"  ) && strcmp ( type, "uint:soa"  ));
+inline int type_error(const uint *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "uint") && strcmp(type, "uint:soa"));
 }
-inline int type_error (const ll     * a, const char *type ) {
-  (void)a; return (strcmp ( type, "ll"    ) && strcmp ( type, "ll:soa"    ));
+inline int type_error(const ll *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "ll") && strcmp(type, "ll:soa"));
 }
-inline int type_error (const ull    * a, const char *type ) {
-  (void)a; return (strcmp ( type, "ull"   ) && strcmp ( type, "ull:soa"   ));
+inline int type_error(const ull *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "ull") && strcmp(type, "ull:soa"));
 }
-inline int type_error (const bool   * a, const char *type ) {
-  (void)a; return (strcmp ( type, "bool"  ) && strcmp ( type, "bool:soa"  ));
+inline int type_error(const bool *a, const char *type) {
+  (void)a;
+  return (strcmp(type, "bool") && strcmp(type, "bool:soa"));
 }
 
 /*
@@ -88,13 +95,13 @@ inline int type_error (const bool   * a, const char *type ) {
  * zero constants
  */
 
-#define ZERO_double  0.0;
-#define ZERO_float   0.0f;
-#define ZERO_int     0;
-#define ZERO_uint    0;
-#define ZERO_ll      0;
-#define ZERO_ull     0;
-#define ZERO_bool    0;
+#define ZERO_double 0.0;
+#define ZERO_float 0.0f;
+#define ZERO_int 0;
+#define ZERO_uint 0;
+#define ZERO_ll 0;
+#define ZERO_ull 0;
+#define ZERO_bool 0;
 
 /*
  * external variables declared in op_lib_core.cpp
@@ -102,127 +109,99 @@ inline int type_error (const bool   * a, const char *type ) {
 
 extern int OP_diags, OP_part_size, OP_block_size, OP_gpu_direct;
 
-extern int OP_set_index,  OP_set_max,
-           OP_map_index,  OP_map_max,
-           OP_dat_index,
-           OP_plan_index, OP_plan_max,
-                          OP_kern_max;
+extern int OP_set_index, OP_set_max, OP_map_index, OP_map_max, OP_dat_index,
+    OP_plan_index, OP_plan_max, OP_kern_max;
 
-extern op_set    * OP_set_list;
-extern op_map    * OP_map_list;
+extern op_set *OP_set_list;
+extern op_map *OP_map_list;
 extern Double_linked_list OP_dat_list;
-extern op_kernel * OP_kernels;
+extern op_kernel *OP_kernels;
 extern double OP_plan_time;
 
-op_dat op_decl_dat_char (op_set, int, char const *, int, char *, char const * );
-op_dat op_decl_dat_temp_char (op_set, int, char const *, int, char const * );
-int op_free_dat_temp_char ( op_dat dat );
+op_dat op_decl_dat_char(op_set, int, char const *, int, char *, char const *);
+op_dat op_decl_dat_temp_char(op_set, int, char const *, int, char const *);
+int op_free_dat_temp_char(op_dat dat);
 
 /* Implementation */
 
-template < class T >
-op_dat op_decl_dat ( op_set set, int dim, char const *type,
-                     T * data, char const * name )
-{
+template <class T>
+op_dat op_decl_dat(op_set set, int dim, char const *type, T *data,
+                   char const *name) {
 
-  if ( type_error ( data, type ) )
-  {
-    printf ( "incorrect type specified for dataset \"%s\" \n", name );
-    exit ( 1 );
+  if (type_error(data, type)) {
+    printf("incorrect type specified for dataset \"%s\" \n", name);
+    exit(1);
   }
 
-  return op_decl_dat_char ( set, dim, type, sizeof(T), (char *) data, name );
+  return op_decl_dat_char(set, dim, type, sizeof(T), (char *)data, name);
 }
 
-template < class T >
-void op_decl_const2 ( char const * name, int dim, char const *type, T * data )
-{
-  if ( type_error ( data, type ) )
-  {
-    printf ( "incorrect type specified for constant \"%s\" \n", name ); exit ( 1 );
+template <class T>
+void op_decl_const2(char const *name, int dim, char const *type, T *data) {
+  if (type_error(data, type)) {
+    printf("incorrect type specified for constant \"%s\" \n", name);
+    exit(1);
   }
 
-  op_decl_const_char ( dim, type, sizeof ( T ), (char *) data, name );
+  op_decl_const_char(dim, type, sizeof(T), (char *)data, name);
 }
 
-template < class T >
-void op_decl_const ( int dim, char const * type, T * data )
-{
+template <class T> void op_decl_const(int dim, char const *type, T *data) {
   (void)dim;
-  if ( type_error ( data, type ) )
-  {
-    printf ( "incorrect type specified for constant in op_decl_const" );
-    exit ( 1 );
+  if (type_error(data, type)) {
+    printf("incorrect type specified for constant in op_decl_const");
+    exit(1);
   }
 }
 
-template < class T >
-op_arg op_arg_gbl ( T * data, int dim, char const * type, op_access acc )
-{
-  if ( type_error ( data, type ) )
-    return op_arg_gbl_char ( ( char *  )data, dim, "error",  sizeof(T), acc );
+template <class T>
+op_arg op_arg_gbl(T *data, int dim, char const *type, op_access acc) {
+  if (type_error(data, type))
+    return op_arg_gbl_char((char *)data, dim, "error", sizeof(T), acc);
   else
-    return op_arg_gbl_char ( ( char * ) data, dim, type,  sizeof(T), acc );
+    return op_arg_gbl_char((char *)data, dim, type, sizeof(T), acc);
 }
 
 //
-//temporary dats
+// temporary dats
 //
-template < class T >
-op_dat op_decl_dat_temp ( op_set set, int dim, char const *type, T* data,
-  char const * name )
-{
-  return op_decl_dat_temp_char ( set, dim, type, sizeof(T), name );
+template <class T>
+op_dat op_decl_dat_temp(op_set set, int dim, char const *type, T *data,
+                        char const *name) {
+  return op_decl_dat_temp_char(set, dim, type, sizeof(T), name);
 }
 
-inline int op_free_dat_temp ( op_dat dat )
-{
-  return op_free_dat_temp_char ( dat );
-}
-
+inline int op_free_dat_temp(op_dat dat) { return op_free_dat_temp_char(dat); }
 
 //
-//fetch data
+// fetch data
 //
-template < class T >
-void op_fetch_data ( op_dat dat, T* usr_ptr)
-{
-  op_fetch_data_char(dat, (char * ) usr_ptr);
+template <class T> void op_fetch_data(op_dat dat, T *usr_ptr) {
+  op_fetch_data_char(dat, (char *)usr_ptr);
 }
 
-template < class T >
-void op_fetch_data_idx (op_dat dat, T* usr_ptr, int low, int high)
-{
-  op_fetch_data_idx_char(dat, (char* )usr_ptr, low, high);
+template <class T>
+void op_fetch_data_idx(op_dat dat, T *usr_ptr, int low, int high) {
+  op_fetch_data_idx_char(dat, (char *)usr_ptr, low, high);
 }
 
 //
 // wrapper functions to handle MPI global reductions
 //
 
-inline void op_mpi_reduce(op_arg* args, float *data)
-{
-  op_mpi_reduce_float(args,data);
+inline void op_mpi_reduce(op_arg *args, float *data) {
+  op_mpi_reduce_float(args, data);
 }
 
-inline void op_mpi_reduce(op_arg* args, double *data)
-{
-  op_mpi_reduce_double(args,data);
+inline void op_mpi_reduce(op_arg *args, double *data) {
+  op_mpi_reduce_double(args, data);
 }
 
-inline void op_mpi_reduce(op_arg* args, int *data)
-{
-  op_mpi_reduce_int(args,data);
+inline void op_mpi_reduce(op_arg *args, int *data) {
+  op_mpi_reduce_int(args, data);
 }
 
-//needed as a dummy, "do nothing" routine for the non-mpi backends
-template <class T>
-void op_mpi_reduce(op_arg* args, T* data)
-{
-
-}
-
-
+// needed as a dummy, "do nothing" routine for the non-mpi backends
+template <class T> void op_mpi_reduce(op_arg *args, T *data) {}
 
 #endif /* __OP_LIB_CPP_H */
-

--- a/op2/c/include/op_lib_mpi.h
+++ b/op2/c/include/op_lib_mpi.h
@@ -44,46 +44,47 @@
 extern MPI_Comm OP_MPI_WORLD;
 extern MPI_Comm OP_MPI_GLOBAL;
 
-extern halo_list *OP_export_exec_list;//EEH list
-extern halo_list *OP_import_exec_list;//IEH list
+extern halo_list *OP_export_exec_list; // EEH list
+extern halo_list *OP_import_exec_list; // IEH list
 
-extern halo_list *OP_import_nonexec_list;//INH list
-extern halo_list *OP_export_nonexec_list;//ENH list
+extern halo_list *OP_import_nonexec_list; // INH list
+extern halo_list *OP_export_nonexec_list; // ENH list
 
 extern int OP_part_index;
 extern part *OP_part_list;
-extern int** orig_part_range;
+extern int **orig_part_range;
 
 /** variables for partial halo exchanges **/
 extern int *OP_map_partial_exchange;
 extern halo_list *OP_import_nonexec_permap;
 extern halo_list *OP_export_nonexec_permap;
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** Gather halo data in buffer on the device **/
-void gather_data_to_buffer(op_arg arg, halo_list exp_exec_list, halo_list exp_nonexec_list);
+void gather_data_to_buffer(op_arg arg, halo_list exp_exec_list,
+                           halo_list exp_nonexec_list);
 void gather_data_to_buffer_partial(op_arg arg, halo_list exp_nonexec_list);
 void scatter_data_from_buffer(op_arg arg);
 void scatter_data_from_buffer_partial(op_arg arg);
 
 op_set op_decl_set_hdf5(char const *file, char const *name);
-op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file, char const *name);
-op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file, char const *name);
+op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
+                        char const *name);
+op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
+                        char const *name);
 
-void op_get_const_hdf5(char const *name, int dim, char const *type, char* const_data,
-  char const *file_name);
+void op_get_const_hdf5(char const *name, int dim, char const *type,
+                       char *const_data, char const *file_name);
 
-void op_dump_to_hdf5(char const * file_name);
-void op_write_const_hdf5(char const *name, int dim, char const *type, char* const_data,
-  char const *file_name);
+void op_dump_to_hdf5(char const *file_name);
+void op_write_const_hdf5(char const *name, int dim, char const *type,
+                         char *const_data, char const *file_name);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __OP_LIB_MPI_H */
-

--- a/op2/c/include/op_mpi_core.h
+++ b/op2/c/include/op_mpi_core.h
@@ -44,7 +44,7 @@
 
 #include <mpi.h>
 
-//use uthash from - http://troydhanson.github.com/uthash/
+// use uthash from - http://troydhanson.github.com/uthash/
 #include <uthash.h>
 
 /** Define the root MPI process **/
@@ -58,37 +58,37 @@
 *******************************************************************************/
 
 typedef struct {
-  //set related to this list
+  // set related to this list
   op_set set;
-  //number of elements in this list
-  int    size;
-  //MPI ranks to be exported to or imported from
-  int    *ranks;
-  //number of MPI neighbors to be exported to or imported from
-  int    ranks_size;
-  //displacements for the starting point of each rank's element list
-  int    *disps;
-  //number of elements exported to or imported from each ranks
-  int    *sizes;
-  //the list of all elements
-  int    *list;
+  // number of elements in this list
+  int size;
+  // MPI ranks to be exported to or imported from
+  int *ranks;
+  // number of MPI neighbors to be exported to or imported from
+  int ranks_size;
+  // displacements for the starting point of each rank's element list
+  int *disps;
+  // number of elements exported to or imported from each ranks
+  int *sizes;
+  // the list of all elements
+  int *list;
 } halo_list_core;
 
-typedef halo_list_core * halo_list;
+typedef halo_list_core *halo_list;
 
 /*******************************************************************************
 * Data structures related to MPI level partitioning
 *******************************************************************************/
 
-//struct to hold the partition information for each set
+// struct to hold the partition information for each set
 typedef struct {
-  //set to which this partition info blongs to
+  // set to which this partition info blongs to
   op_set set;
-  //global index of each element held in this MPI process
+  // global index of each element held in this MPI process
   int *g_index;
-  //partition to which each element belongs
+  // partition to which each element belongs
   int *elem_part;
-  //indicates if this set is partitioned 1 if partitioned 0 if not
+  // indicates if this set is partitioned 1 if partitioned 0 if not
   int is_partitioned;
 } part_core;
 
@@ -98,17 +98,17 @@ typedef part_core *part;
 * Data structure to hold mpi communications of an op_dat
 *******************************************************************************/
 #define NAMESIZE 20
-typedef struct{
-  //name of this op_dat
-  char  name[NAMESIZE];
-  //size of this op_dat
-  int         size;
-  //index of this op_dat
-  int         index;
-  //total number of times this op_dat was halo exported
-  int         count;
-  //total number of bytes halo exported for this op_dat in this kernel
-  int         bytes;
+typedef struct {
+  // name of this op_dat
+  char name[NAMESIZE];
+  // size of this op_dat
+  int size;
+  // index of this op_dat
+  int index;
+  // total number of times this op_dat was halo exported
+  int count;
+  // total number of bytes halo exported for this op_dat in this kernel
+  int bytes;
 } op_dat_mpi_comm_info_core;
 
 typedef op_dat_mpi_comm_info_core *op_dat_mpi_comm_info;
@@ -119,40 +119,39 @@ typedef op_dat_mpi_comm_info_core *op_dat_mpi_comm_info;
 
 typedef struct {
 
-  UT_hash_handle hh;   //with this variable uthash makes this structure hashable
+  UT_hash_handle hh; // with this variable uthash makes this structure hashable
 
   // name of kernel
-  char  name[NAMESIZE];
-  //total time spent in this kernel (compute + comm - overlap)
-  double      time;
-  //number of times this kernel is called
-  int         count;
-  //number of op_dat indices in this kernel
-  int         num_indices;
+  char name[NAMESIZE];
+  // total time spent in this kernel (compute + comm - overlap)
+  double time;
+  // number of times this kernel is called
+  int count;
+  // number of op_dat indices in this kernel
+  int num_indices;
   // array to hold all the op_dat_mpi_comm_info structs for this kernel
-  op_dat_mpi_comm_info* comm_info;
+  op_dat_mpi_comm_info *comm_info;
   // capacity of comm_info array
   int cap;
 } op_mpi_kernel;
-
 
 /*******************************************************************************
 * Buffer struct used in non-blocking mpi halo sends/receives
 *******************************************************************************/
 
 typedef struct {
-  //buffer holding exec halo to be exported;
-  char        *buf_exec;
-  //buffer holding nonexec halo to be exported;
-  char        *buf_nonexec;
-  //pointed to hold the MPI_Reqest for sends
+  // buffer holding exec halo to be exported;
+  char *buf_exec;
+  // buffer holding nonexec halo to be exported;
+  char *buf_nonexec;
+  // pointed to hold the MPI_Reqest for sends
   MPI_Request *s_req;
-  //pointed to hold the MPI_Reqest for receives
+  // pointed to hold the MPI_Reqest for receives
   MPI_Request *r_req;
-  //number of send MPI_Reqests in flight at a given time for this op_dat
-  int         s_num_req;
-  //number of receive MPI_Reqests in flight at a given time for this op_dat
-  int         r_num_req;
+  // number of send MPI_Reqests in flight at a given time for this op_dat
+  int s_num_req;
+  // number of receive MPI_Reqests in flight at a given time for this op_dat
+  int r_num_req;
 } op_mpi_buffer_core;
 
 typedef op_mpi_buffer_core *op_mpi_buffer;
@@ -161,14 +160,14 @@ typedef op_mpi_buffer_core *op_mpi_buffer;
 
 extern int OP_part_index;
 extern part *OP_part_list;
-extern int** orig_part_range;
+extern int **orig_part_range;
 
 /** export list on the device **/
 
-extern int** export_exec_list_d;
-extern int** export_nonexec_list_d;
-extern int** export_nonexec_list_partial_d;
-extern int** import_nonexec_list_partial_d;
+extern int **export_exec_list_d;
+extern int **export_nonexec_list_d;
+extern int **export_nonexec_list_partial_d;
+extern int **import_nonexec_list_partial_d;
 extern int *set_import_buffer_size;
 
 /*******************************************************************************
@@ -196,7 +195,7 @@ typedef struct {
   char *OP_global_buffer;
   int OP_global_buffer_size;
 
-  int gbl_num_ifaces ;
+  int gbl_num_ifaces;
   int *gbl_iface_list;
   int *nprocs_per_gint;
   int **proclist_per_gint;
@@ -234,7 +233,6 @@ typedef struct {
 
 typedef op_import_core *op_import_handle;
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -243,49 +241,31 @@ extern "C" {
 * Utility function prototypes
 *******************************************************************************/
 
-void decl_partition(op_set set, int* g_index, int* partition);
+void decl_partition(op_set set, int *g_index, int *partition);
 
-void get_part_range(int** part_range, int my_rank, int comm_size, MPI_Comm Comm);
+void get_part_range(int **part_range, int my_rank, int comm_size,
+                    MPI_Comm Comm);
 
-int get_partition(int global_index, int* part_range, int* local_index, int comm_size);
+int get_partition(int global_index, int *part_range, int *local_index,
+                  int comm_size);
 
-int get_global_index(int local_index, int partition, int* part_range, int comm_size);
+int get_global_index(int local_index, int partition, int *part_range,
+                     int comm_size);
 
-void find_neighbors_set(halo_list List,
-                        int* neighbors,
-                        int* sizes,
-                        int* ranks_size,
-                        int my_rank,
-                        int comm_size,
+void find_neighbors_set(halo_list List, int *neighbors, int *sizes,
+                        int *ranks_size, int my_rank, int comm_size,
                         MPI_Comm Comm);
 
-void create_list( int* list,
-                  int* ranks,
-                  int* disps,
-                  int* sizes,
-                  int* ranks_size,
-                  int* total,
-                  int* temp_list,
-                  int size,
-                  int comm_size,
-                  int my_rank );
+void create_list(int *list, int *ranks, int *disps, int *sizes, int *ranks_size,
+                 int *total, int *temp_list, int size, int comm_size,
+                 int my_rank);
 
-void create_export_list(op_set set,
-                        int* temp_list,
-                        halo_list h_list,
-                        int size,
-                        int comm_size,
-                        int my_rank);
+void create_export_list(op_set set, int *temp_list, halo_list h_list, int size,
+                        int comm_size, int my_rank);
 
-void create_import_list(op_set set,
-                        int* temp_list,
-                        halo_list h_list,
-                        int total_size,
-                        int* ranks,
-                        int* sizes,
-                        int ranks_size,
-                        int comm_size,
-                        int my_rank);
+void create_import_list(op_set set, int *temp_list, halo_list h_list,
+                        int total_size, int *ranks, int *sizes, int ranks_size,
+                        int comm_size, int my_rank);
 
 int is_onto_map(op_map map);
 
@@ -301,7 +281,7 @@ void op_halo_destroy();
 
 op_dat op_mpi_get_data(op_dat dat);
 
-void fetch_data_hdf5(op_dat dat, char* usr_ptr, int low, int high);
+void fetch_data_hdf5(op_dat dat, char *usr_ptr, int low, int high);
 
 void mpi_timing_output();
 
@@ -313,8 +293,10 @@ void print_dat_to_binfile_mpi(op_dat dat, const char *file_name);
 
 void op_mpi_put_data(op_dat dat);
 
-void op_mpi_init ( int argc, char ** argv, int diags, MPI_Fint global, MPI_Fint local );
-void op_mpi_init_soa ( int argc, char ** argv, int diags, MPI_Fint global, MPI_Fint local, int soa );
+void op_mpi_init(int argc, char **argv, int diags, MPI_Fint global,
+                 MPI_Fint local);
+void op_mpi_init_soa(int argc, char **argv, int diags, MPI_Fint global,
+                     MPI_Fint local, int soa);
 
 /* Defined in op_mpi_decl.c, may need to be put in a seperate headder file */
 void op_mv_halo_device(op_set set, op_dat dat);
@@ -322,8 +304,8 @@ void op_mv_halo_device(op_set set, op_dat dat);
 /* Defined in op_mpi_decl.c, may need to be put in a seperate headder file */
 void op_mv_halo_list_device();
 
-void partition(const char* lib_name, const char* lib_routine,
-  op_set prime_set, op_map prime_map, op_dat coords );
+void partition(const char *lib_name, const char *lib_routine, op_set prime_set,
+               op_map prime_map, op_dat coords);
 
 /******************************************************************************
 * Custom partitioning wrapper prototypes
@@ -346,7 +328,7 @@ void op_partition_kway(op_map primary_map);
 
 void op_partition_geomkway(op_dat coords, op_map primary_map);
 
-void op_partition_meshkway(op_map primary_map); //does not work
+void op_partition_meshkway(op_map primary_map); // does not work
 #endif
 
 #ifdef HAVE_PTSCOTCH
@@ -357,16 +339,19 @@ void op_partition_meshkway(op_map primary_map); //does not work
 void op_partition_ptscotch(op_map primary_map);
 #endif
 
-
 /*******************************************************************************
 * Sliding planes functionality
 *******************************************************************************/
-  op_export_handle op_export_init(int nprocs, int *proclist, op_map cellsToNodes, op_set sp_nodes, op_dat coords, op_dat mark);
-  void op_export_data(op_export_handle handle, op_dat dat);
-  op_import_handle op_import_init(op_export_handle exp_handle, op_dat coords, op_dat mark);
-  void op_inc_theta(op_export_handle handle, int *sp_id, double *dtheta1, double *dtheta2);
-  void op_import_data(op_import_handle handle, op_dat dat);
-  void op_theta_init(op_export_handle handle, int *sp_id, double *dtheta1, double *dtheta2, double *alpha);
+op_export_handle op_export_init(int nprocs, int *proclist, op_map cellsToNodes,
+                                op_set sp_nodes, op_dat coords, op_dat mark);
+void op_export_data(op_export_handle handle, op_dat dat);
+op_import_handle op_import_init(op_export_handle exp_handle, op_dat coords,
+                                op_dat mark);
+void op_inc_theta(op_export_handle handle, int *sp_id, double *dtheta1,
+                  double *dtheta2);
+void op_import_data(op_import_handle handle, op_dat dat);
+void op_theta_init(op_export_handle handle, int *sp_id, double *dtheta1,
+                   double *dtheta2, double *alpha);
 
 #ifdef __cplusplus
 }
@@ -376,14 +361,13 @@ void op_partition_ptscotch(op_map primary_map);
 * External functions defined in op_mpi_(cuda)_rt_support.c
 *******************************************************************************/
 
-void op_exchange_halo(op_arg* arg, int exec_flag);
-void op_exchange_halo_partial(op_arg* arg, int exec_flag);
-void op_wait_all(op_arg* arg);
-void op_exchange_halo_cuda(op_arg* arg, int exec_flag);
-void op_exchange_halo_partial_cuda(op_arg* arg, int exec_flag);
-void op_wait_all_cuda(op_arg* arg);
+void op_exchange_halo(op_arg *arg, int exec_flag);
+void op_exchange_halo_partial(op_arg *arg, int exec_flag);
+void op_wait_all(op_arg *arg);
+void op_exchange_halo_cuda(op_arg *arg, int exec_flag);
+void op_exchange_halo_partial_cuda(op_arg *arg, int exec_flag);
+void op_wait_all_cuda(op_arg *arg);
 void op_upload_dat(op_dat dat);
 void op_download_dat(op_dat dat);
 
 #endif /* __OP_MPI_CORE_H */
-

--- a/op2/c/include/op_openmp_rt_support.h
+++ b/op2/c/include/op_openmp_rt_support.h
@@ -44,7 +44,6 @@
 extern "C" {
 #endif
 
-
 /*
  * Plan interface for generated code: the implementation changes depending
  * on the actual back-end libraries (e.g. cuda or openmp) and it is
@@ -55,14 +54,14 @@ extern "C" {
  * (e.g. op_plan_core)
  */
 
-op_plan *op_plan_get ( char const *name, op_set set, int part_size,
-                       int nargs, op_arg *args, int ninds, int *inds );
+op_plan *op_plan_get(char const *name, op_set set, int part_size, int nargs,
+                     op_arg *args, int ninds, int *inds);
 
-op_plan *op_plan_get_stage ( char const * name, op_set set, int part_size,
-                       int nargs, op_arg * args, int ninds, int * inds, int staging );
+op_plan *op_plan_get_stage(char const *name, op_set set, int part_size,
+                           int nargs, op_arg *args, int ninds, int *inds,
+                           int staging);
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __OP_OPENMP_RT_SUPPPORT_H */
-

--- a/op2/c/include/op_rt_support.h
+++ b/op2/c/include/op_rt_support.h
@@ -34,8 +34,10 @@
 #define __OP_RT_SUPPORT_H
 
 /*
- * This header file defines the data structures required in the OP2 run-time support,
- * i.e. those related to OP2 plans, and it declares the low-level routines used to
+ * This header file defines the data structures required in the OP2 run-time
+ * support,
+ * i.e. those related to OP2 plans, and it declares the low-level routines used
+ * to
  * build OP2 plans
  */
 
@@ -43,70 +45,74 @@
 
 typedef struct {
   /* input arguments */
-  char const  *name;
-  op_set       set;
-  int          nargs, ninds, ninds_staged, part_size;
-  op_map      *maps;
-  op_dat      *dats;
-  int         *idxs;
-  int         *optflags;
-  op_access   *accs;
-  int         *inds_staged;
+  char const *name;
+  op_set set;
+  int nargs, ninds, ninds_staged, part_size;
+  op_map *maps;
+  op_dat *dats;
+  int *idxs;
+  int *optflags;
+  op_access *accs;
+  int *inds_staged;
 
   /* execution plan */
-  int        *nthrcol;    /* number of thread colors for each block */
-  int        *thrcol;     /* thread colors */
-  int        *col_reord;  /* permutation of elements by block color */
-  int       **col_offsets; /* offsets to beginning of colors for each block */
-  int        *offset;     /* offset for primary set */
-  int        *offset_d;   /* offset for primary set on the GPU (Fortran)*/
-  int        *ind_map;    /* concatenated pointers for indirect datasets */
-  int       **ind_maps;   /* pointers for indirect datasets */
-  int        *ind_offs;   /* block offsets for indirect datasets */
-  int        *ind_sizes;  /* block sizes for indirect datasets */
-  int        *nindirect;  /* total sizes for indirect datasets */
-  short      *loc_map;    /* concatenated maps to local indices, renumbered as needed */
-  short     **loc_maps;   /* maps to local indices, renumbered as needed */
-  int         nblocks;    /* number of blocks */
-  int        *nelems;     /* number of elements in each block */
-  int        *nelems_d;   /* number of elements in each block on the GPU (Fortran) */
-  int         ncolors_core; /* mumber of core colors in MPI */
-  int         ncolors_owned; /* mumber of colors in MPI for blocks that only have owned elements*/
-  int         ncolors;    /* number of block colors */
-  int        *ncolblk;    /* number of blocks for each color */
-  int        *blkmap;     /* block mapping */
-  int        *blkmap_d;   /* block mapping on the GPU (Fortran) */
-  int        *nsharedCol; /* bytes of shared memory required per block colour */
-  int         nshared;    /* bytes of shared memory required */
-  float       transfer;   /* bytes of data transfer per kernel call */
-  float       transfer2;  /* bytes of cache line per kernel call */
-  int         count;      /* number of times called */
+  int *nthrcol;      /* number of thread colors for each block */
+  int *thrcol;       /* thread colors */
+  int *col_reord;    /* permutation of elements by block color */
+  int **col_offsets; /* offsets to beginning of colors for each block */
+  int *offset;       /* offset for primary set */
+  int *offset_d;     /* offset for primary set on the GPU (Fortran)*/
+  int *ind_map;      /* concatenated pointers for indirect datasets */
+  int **ind_maps;    /* pointers for indirect datasets */
+  int *ind_offs;     /* block offsets for indirect datasets */
+  int *ind_sizes;    /* block sizes for indirect datasets */
+  int *nindirect;    /* total sizes for indirect datasets */
+  short *loc_map; /* concatenated maps to local indices, renumbered as needed */
+  short **loc_maps;  /* maps to local indices, renumbered as needed */
+  int nblocks;       /* number of blocks */
+  int *nelems;       /* number of elements in each block */
+  int *nelems_d;     /* number of elements in each block on the GPU (Fortran) */
+  int ncolors_core;  /* mumber of core colors in MPI */
+  int ncolors_owned; /* mumber of colors in MPI for blocks that only have owned
+                        elements*/
+  int ncolors;       /* number of block colors */
+  int *ncolblk;      /* number of blocks for each color */
+  int *blkmap;       /* block mapping */
+  int *blkmap_d;     /* block mapping on the GPU (Fortran) */
+  int *nsharedCol;   /* bytes of shared memory required per block colour */
+  int nshared;       /* bytes of shared memory required */
+  float transfer;    /* bytes of data transfer per kernel call */
+  float transfer2;   /* bytes of cache line per kernel call */
+  int count;         /* number of times called */
 } op_plan;
 
-extern op_plan * OP_plans;
+extern op_plan *OP_plans;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-op_plan * op_plan_old_core ( char const *, op_set, int, int, op_dat *,
-                             int *, op_map *, int *, char const **, op_access *, int, int * );
+op_plan *op_plan_old_core(char const *, op_set, int, int, op_dat *, int *,
+                          op_map *, int *, char const **, op_access *, int,
+                          int *);
 
-op_plan * op_plan_core ( char const *, op_set, int, int, op_arg *, int, int *, int );
+op_plan *op_plan_core(char const *, op_set, int, int, op_arg *, int, int *,
+                      int);
 
-op_plan * op_plan_get_stage ( char const * name, op_set set, int part_size,
-                        int nargs, op_arg * args, int ninds, int * inds, int staging );
+op_plan *op_plan_get_stage(char const *name, op_set set, int part_size,
+                           int nargs, op_arg *args, int ninds, int *inds,
+                           int staging);
 
-op_plan * op_plan_get ( char const * name, op_set set, int part_size,
-                        int nargs, op_arg * args, int ninds, int * inds );
+op_plan *op_plan_get(char const *name, op_set set, int part_size, int nargs,
+                     op_arg *args, int ninds, int *inds);
 
-void op_plan_check ( op_plan OP_plan, int ninds, int * inds );
+void op_plan_check(op_plan OP_plan, int ninds, int *inds);
 
-void op_rt_exit ( void );
+void op_rt_exit(void);
 
 bool op_type_equivalence(const char *a, const char *b);
 
-int getSetSizeFromOpArg (op_arg * arg);
+int getSetSizeFromOpArg(op_arg *arg);
 
 #ifdef __cplusplus
 }

--- a/op2/c/include/op_seq.h
+++ b/op2/c/include/op_seq.h
@@ -10,63 +10,62 @@ static int op2_stride = 1;
 
 // scratch space to use for double counting in indirect reduction
 static int blank_args_size = 512;
-static char* blank_args = (char *)op_malloc(blank_args_size);
+static char *blank_args = (char *)op_malloc(blank_args_size);
 
-inline void op_arg_set(int n, op_arg arg, char **p_arg, int halo){
+inline void op_arg_set(int n, op_arg arg, char **p_arg, int halo) {
   *p_arg = arg.data;
 
-  if (arg.argtype==OP_ARG_GBL) {
-    if (halo && (arg.acc != OP_READ)) *p_arg = blank_args;
-  }
-  else {
-    if (arg.map==NULL || arg.opt==0)         // identity mapping
-      *p_arg += arg.size*n;
-    else                       // standard pointers
-      *p_arg += arg.size*arg.map->map[arg.idx+n*arg.map->dim];
+  if (arg.argtype == OP_ARG_GBL) {
+    if (halo && (arg.acc != OP_READ))
+      *p_arg = blank_args;
+  } else {
+    if (arg.map == NULL || arg.opt == 0) // identity mapping
+      *p_arg += arg.size * n;
+    else // standard pointers
+      *p_arg += arg.size * arg.map->map[arg.idx + n * arg.map->dim];
   }
 }
 
 inline void op_arg_copy_in(int n, op_arg arg, char **p_arg) {
-  for (int i = 0; i < -1*arg.idx; ++i)
-    p_arg[i] = arg.data + arg.map->map[i+n*arg.map->dim]*arg.size;
+  for (int i = 0; i < -1 * arg.idx; ++i)
+    p_arg[i] = arg.data + arg.map->map[i + n * arg.map->dim] * arg.size;
 }
 
-inline void op_args_check(op_set set, int nargs, op_arg *args,
-                                      int *ninds, const char *name) {
-  for (int n=0; n<nargs; n++)
-    op_arg_check(set,n,args[n],ninds,name);
+inline void op_args_check(op_set set, int nargs, op_arg *args, int *ninds,
+                          const char *name) {
+  for (int n = 0; n < nargs; n++)
+    op_arg_check(set, n, args[n], ninds, name);
 }
 
 //
-//op_par_loop routine for 1 arguments
+// op_par_loop routine for 1 arguments
 //
 template <class T0>
-void op_par_loop(void (*kernel)(T0*),
-    char const * name, op_set set,
-    op_arg arg0){
+void op_par_loop(void (*kernel)(T0 *), char const *name, op_set set,
+                 op_arg arg0) {
 
   char *p_a[1] = {0};
   op_arg args[1] = {arg0};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<1;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 1; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,1,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 1, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -78,23 +77,27 @@ void op_par_loop(void (*kernel)(T0*),
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(1,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(1, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
 
-    kernel( (T0 *)p_a[0]);
+    kernel((T0 *)p_a[0]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (1,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(1, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(1, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -105,43 +108,42 @@ void op_par_loop(void (*kernel)(T0*),
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
 }
 //
-//op_par_loop routine for 2 arguments
+// op_par_loop routine for 2 arguments
 //
-template <class T0,class T1>
-void op_par_loop(void (*kernel)(T0*, T1*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1){
+template <class T0, class T1>
+void op_par_loop(void (*kernel)(T0 *, T1 *), char const *name, op_set set,
+                 op_arg arg0, op_arg arg1) {
 
-  char *p_a[2] = {0,0};
+  char *p_a[2] = {0, 0};
   op_arg args[2] = {arg0, arg1};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<2;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 2; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,2,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 2, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -153,26 +155,32 @@ void op_par_loop(void (*kernel)(T0*, T1*),
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(2,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(2, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (2,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(2, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(2, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -183,49 +191,48 @@ void op_par_loop(void (*kernel)(T0*, T1*),
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
 }
 //
-//op_par_loop routine for 3 arguments
+// op_par_loop routine for 3 arguments
 //
-template <class T0,class T1,class T2>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2){
+template <class T0, class T1, class T2>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *), char const *name, op_set set,
+                 op_arg arg0, op_arg arg1, op_arg arg2) {
 
-  char *p_a[3] = {0,0,0};
+  char *p_a[3] = {0, 0, 0};
   op_arg args[3] = {arg0, arg1, arg2};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<3;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 3; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,3,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 3, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -237,29 +244,37 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*),
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(3,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(3, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (3,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(3, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(3, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -270,55 +285,55 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*),
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
 }
 //
-//op_par_loop routine for 4 arguments
+// op_par_loop routine for 4 arguments
 //
-template <class T0,class T1,class T2,class T3>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3){
+template <class T0, class T1, class T2, class T3>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *), char const *name,
+                 op_set set, op_arg arg0, op_arg arg1, op_arg arg2,
+                 op_arg arg3) {
 
-  char *p_a[4] = {0,0,0,0};
+  char *p_a[4] = {0, 0, 0, 0};
   op_arg args[4] = {arg0, arg1, arg2, arg3};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<4;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 4; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,4,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 4, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -330,32 +345,42 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*),
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(4,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(4, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (4,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(4, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(4, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -366,65 +391,61 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*),
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
 }
 //
-//op_par_loop routine for 5 arguments
+// op_par_loop routine for 5 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4){
+template <class T0, class T1, class T2, class T3, class T4>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *), char const *name,
+                 op_set set, op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
+                 op_arg arg4) {
 
-  char *p_a[5] = {0,0,0,0,0};
-  op_arg args[5] = {arg0, arg1, arg2, arg3,
-                    arg4};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[5] = {0, 0, 0, 0, 0};
+  op_arg args[5] = {arg0, arg1, arg2, arg3, arg4};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<5;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 5; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,5,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 5, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -436,36 +457,48 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(5,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(5, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
+           (T4 *)p_a[4]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (5,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(5, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(5, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -476,71 +509,67 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
 }
 //
-//op_par_loop routine for 6 arguments
+// op_par_loop routine for 6 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5){
+template <class T0, class T1, class T2, class T3, class T4, class T5>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5) {
 
-  char *p_a[6] = {0,0,0,0,0,0};
-  op_arg args[6] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[6] = {0, 0, 0, 0, 0, 0};
+  op_arg args[6] = {arg0, arg1, arg2, arg3, arg4, arg5};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<6;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 6; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,6,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 6, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -552,39 +581,53 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(6,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(6, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (6,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(6, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(6, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -595,77 +638,74 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
 }
 //
-//op_par_loop routine for 7 arguments
+// op_par_loop routine for 7 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6) {
 
-  char *p_a[7] = {0,0,0,0,0,0,0};
-  op_arg args[7] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[7] = {0, 0, 0, 0, 0, 0, 0};
+  op_arg args[7] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<7;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 7; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,7,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 7, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -677,42 +717,58 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(7,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(7, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (7,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(7, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(7, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -723,83 +779,81 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
 }
 //
-//op_par_loop routine for 8 arguments
+// op_par_loop routine for 8 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7) {
 
-  char *p_a[8] = {0,0,0,0,0,0,0,0};
-  op_arg args[8] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[8] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<8;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 8; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,8,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 8, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -811,45 +865,63 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(8,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(8, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (8,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(8, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(8, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -860,93 +932,88 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
 }
 //
-//op_par_loop routine for 9 arguments
+// op_par_loop routine for 9 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8) {
 
-  char *p_a[9] = {0,0,0,0,0,0,0,0,0};
-  op_arg args[9] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[9] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<9;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 9; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,9,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 9, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -958,49 +1025,68 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(9,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(9, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (9,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(9, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(9, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1011,99 +1097,95 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
 }
 //
-//op_par_loop routine for 10 arguments
+// op_par_loop routine for 10 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9) {
 
-  char *p_a[10] = {0,0,0,0,0,0,0,0,0,0};
-  op_arg args[10] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[10] = {arg0, arg1, arg2, arg3, arg4,
+                     arg5, arg6, arg7, arg8, arg9};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<10;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 10; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,10,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 10, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -1115,52 +1197,74 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(10,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(10, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8],
+           (T9 *)p_a[9]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (10,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(10, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(10, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1171,105 +1275,102 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
 }
 //
-//op_par_loop routine for 11 arguments
+// op_par_loop routine for 11 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10) {
 
-  char *p_a[11] = {0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[11] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[11] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[11] = {arg0, arg1, arg2, arg3, arg4, arg5,
+                     arg6, arg7, arg8, arg9, arg10};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<11;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 11; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,11,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 11, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -1281,55 +1382,79 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(11,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(11, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (11,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(11, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(11, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1340,111 +1465,108 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
 }
 //
-//op_par_loop routine for 12 arguments
+// op_par_loop routine for 12 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11) {
 
-  char *p_a[12] = {0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[12] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[12] = {arg0, arg1, arg2, arg3, arg4,  arg5,
+                     arg6, arg7, arg8, arg9, arg10, arg11};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<12;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 12; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,12,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 12, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -1456,58 +1578,84 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(12,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(12, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (12,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(12, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(12, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1518,121 +1666,114 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
 }
 //
-//op_par_loop routine for 13 arguments
+// op_par_loop routine for 13 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12) {
 
-  char *p_a[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[13] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[13] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[13] = {arg0, arg1, arg2, arg3,  arg4,  arg5, arg6,
+                     arg7, arg8, arg9, arg10, arg11, arg12};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<13;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 13; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,13,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 13, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -1644,62 +1785,89 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(13,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(13, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (13,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(13, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(13, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1710,127 +1878,121 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
 }
 //
-//op_par_loop routine for 14 arguments
+// op_par_loop routine for 14 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13) {
 
-  char *p_a[14] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[14] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[14] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[14] = {arg0, arg1, arg2, arg3,  arg4,  arg5,  arg6,
+                     arg7, arg8, arg9, arg10, arg11, arg12, arg13};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<14;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 14; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,14,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 14, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -1842,65 +2004,94 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(14,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(14, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (14,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(14, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(14, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -1911,133 +2102,128 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
 }
 //
-//op_par_loop routine for 15 arguments
+// op_par_loop routine for 15 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14) {
 
-  char *p_a[15] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[15] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[15] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[15] = {arg0, arg1, arg2,  arg3,  arg4,  arg5,  arg6, arg7,
+                     arg8, arg9, arg10, arg11, arg12, arg13, arg14};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<15;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 15; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,15,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 15, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -2049,68 +2235,100 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(15,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(15, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (15,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(15, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(15, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -2121,139 +2339,135 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
 }
 //
-//op_par_loop routine for 16 arguments
+// op_par_loop routine for 16 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14,class T15>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*, T15*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14, op_arg arg15){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14, class T15>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *,
+                                T15 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14, op_arg arg15) {
 
-  char *p_a[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[16] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14, arg15};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[16] = {arg0, arg1, arg2,  arg3,  arg4,  arg5,  arg6,  arg7,
+                     arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
-  if(arg15.idx < -1) {
-    p_a[15] = (char *)op_malloc(-1*args[15].idx*sizeof(T15));
+  if (arg15.idx < -1) {
+    p_a[15] = (char *)op_malloc(-1 * args[15].idx * sizeof(T15));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<16;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 16; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,16,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 16, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -2265,71 +2479,105 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(16,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
-    if (args[15].idx < -1) op_arg_copy_in(n,args[15], (char **)p_a[15]);
-    else op_arg_set(n,args[15], &p_a[15],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(16, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
+    if (args[15].idx < -1)
+      op_arg_copy_in(n, args[15], (char **)p_a[15]);
+    else
+      op_arg_set(n, args[15], &p_a[15], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14], (T15 *)p_a[15]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14], (T15 *)p_a[15]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (16,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(16, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(16, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
-  op_mpi_reduce(&arg15,(T15 *)p_a[15]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
+  op_mpi_reduce(&arg15, (T15 *)p_a[15]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -2340,149 +2588,141 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
-  if(arg15.idx < -1) {
+  if (arg15.idx < -1) {
     free(p_a[15]);
   }
 }
 //
-//op_par_loop routine for 17 arguments
+// op_par_loop routine for 17 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14,class T15,
-          class T16>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*, T15*,
-                                T16*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14, op_arg arg15,
-    op_arg arg16){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14, class T15, class T16>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *,
+                                T15 *, T16 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14, op_arg arg15, op_arg arg16) {
 
-  char *p_a[17] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[17] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14, arg15,
-                    arg16};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[17] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[17] = {arg0, arg1,  arg2,  arg3,  arg4,  arg5,  arg6,  arg7, arg8,
+                     arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
-  if(arg15.idx < -1) {
-    p_a[15] = (char *)op_malloc(-1*args[15].idx*sizeof(T15));
+  if (arg15.idx < -1) {
+    p_a[15] = (char *)op_malloc(-1 * args[15].idx * sizeof(T15));
   }
-  if(arg16.idx < -1) {
-    p_a[16] = (char *)op_malloc(-1*args[16].idx*sizeof(T16));
+  if (arg16.idx < -1) {
+    p_a[16] = (char *)op_malloc(-1 * args[16].idx * sizeof(T16));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<17;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 17; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,17,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 17, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -2494,75 +2734,110 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(17,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
-    if (args[15].idx < -1) op_arg_copy_in(n,args[15], (char **)p_a[15]);
-    else op_arg_set(n,args[15], &p_a[15],halo);
-    if (args[16].idx < -1) op_arg_copy_in(n,args[16], (char **)p_a[16]);
-    else op_arg_set(n,args[16], &p_a[16],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(17, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
+    if (args[15].idx < -1)
+      op_arg_copy_in(n, args[15], (char **)p_a[15]);
+    else
+      op_arg_set(n, args[15], &p_a[15], halo);
+    if (args[16].idx < -1)
+      op_arg_copy_in(n, args[16], (char **)p_a[16]);
+    else
+      op_arg_set(n, args[16], &p_a[16], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14], (T15 *)p_a[15],
-          (T16 *)p_a[16]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14], (T15 *)p_a[15], (T16 *)p_a[16]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (17,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(17, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(17, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
-  op_mpi_reduce(&arg15,(T15 *)p_a[15]);
-  op_mpi_reduce(&arg16,(T16 *)p_a[16]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
+  op_mpi_reduce(&arg15, (T15 *)p_a[15]);
+  op_mpi_reduce(&arg16, (T16 *)p_a[16]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -2573,155 +2848,148 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
-  if(arg15.idx < -1) {
+  if (arg15.idx < -1) {
     free(p_a[15]);
   }
-  if(arg16.idx < -1) {
+  if (arg16.idx < -1) {
     free(p_a[16]);
   }
 }
 //
-//op_par_loop routine for 18 arguments
+// op_par_loop routine for 18 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14,class T15,
-          class T16,class T17>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*, T15*,
-                                T16*, T17*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14, op_arg arg15,
-    op_arg arg16, op_arg arg17){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14, class T15, class T16, class T17>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *,
+                                T15 *, T16 *, T17 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14, op_arg arg15, op_arg arg16, op_arg arg17) {
 
-  char *p_a[18] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[18] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14, arg15,
-                    arg16, arg17};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[18] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[18] = {arg0,  arg1,  arg2,  arg3,  arg4,  arg5,
+                     arg6,  arg7,  arg8,  arg9,  arg10, arg11,
+                     arg12, arg13, arg14, arg15, arg16, arg17};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
-  if(arg15.idx < -1) {
-    p_a[15] = (char *)op_malloc(-1*args[15].idx*sizeof(T15));
+  if (arg15.idx < -1) {
+    p_a[15] = (char *)op_malloc(-1 * args[15].idx * sizeof(T15));
   }
-  if(arg16.idx < -1) {
-    p_a[16] = (char *)op_malloc(-1*args[16].idx*sizeof(T16));
+  if (arg16.idx < -1) {
+    p_a[16] = (char *)op_malloc(-1 * args[16].idx * sizeof(T16));
   }
-  if(arg17.idx < -1) {
-    p_a[17] = (char *)op_malloc(-1*args[17].idx*sizeof(T17));
+  if (arg17.idx < -1) {
+    p_a[17] = (char *)op_malloc(-1 * args[17].idx * sizeof(T17));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<18;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 18; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,18,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 18, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -2733,78 +3001,115 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(18,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
-    if (args[15].idx < -1) op_arg_copy_in(n,args[15], (char **)p_a[15]);
-    else op_arg_set(n,args[15], &p_a[15],halo);
-    if (args[16].idx < -1) op_arg_copy_in(n,args[16], (char **)p_a[16]);
-    else op_arg_set(n,args[16], &p_a[16],halo);
-    if (args[17].idx < -1) op_arg_copy_in(n,args[17], (char **)p_a[17]);
-    else op_arg_set(n,args[17], &p_a[17],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(18, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
+    if (args[15].idx < -1)
+      op_arg_copy_in(n, args[15], (char **)p_a[15]);
+    else
+      op_arg_set(n, args[15], &p_a[15], halo);
+    if (args[16].idx < -1)
+      op_arg_copy_in(n, args[16], (char **)p_a[16]);
+    else
+      op_arg_set(n, args[16], &p_a[16], halo);
+    if (args[17].idx < -1)
+      op_arg_copy_in(n, args[17], (char **)p_a[17]);
+    else
+      op_arg_set(n, args[17], &p_a[17], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14], (T15 *)p_a[15],
-          (T16 *)p_a[16], (T17 *)p_a[17]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14], (T15 *)p_a[15], (T16 *)p_a[16], (T17 *)p_a[17]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (18,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(18, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(18, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
-  op_mpi_reduce(&arg15,(T15 *)p_a[15]);
-  op_mpi_reduce(&arg16,(T16 *)p_a[16]);
-  op_mpi_reduce(&arg17,(T17 *)p_a[17]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
+  op_mpi_reduce(&arg15, (T15 *)p_a[15]);
+  op_mpi_reduce(&arg16, (T16 *)p_a[16]);
+  op_mpi_reduce(&arg17, (T17 *)p_a[17]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -2815,161 +3120,155 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
-  if(arg15.idx < -1) {
+  if (arg15.idx < -1) {
     free(p_a[15]);
   }
-  if(arg16.idx < -1) {
+  if (arg16.idx < -1) {
     free(p_a[16]);
   }
-  if(arg17.idx < -1) {
+  if (arg17.idx < -1) {
     free(p_a[17]);
   }
 }
 //
-//op_par_loop routine for 19 arguments
+// op_par_loop routine for 19 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14,class T15,
-          class T16,class T17,class T18>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*, T15*,
-                                T16*, T17*, T18*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14, op_arg arg15,
-    op_arg arg16, op_arg arg17, op_arg arg18){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14, class T15, class T16, class T17, class T18>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *,
+                                T15 *, T16 *, T17 *, T18 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14, op_arg arg15, op_arg arg16, op_arg arg17,
+                 op_arg arg18) {
 
-  char *p_a[19] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[19] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14, arg15,
-                    arg16, arg17, arg18};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[19] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[19] = {arg0,  arg1,  arg2,  arg3,  arg4,  arg5,  arg6,
+                     arg7,  arg8,  arg9,  arg10, arg11, arg12, arg13,
+                     arg14, arg15, arg16, arg17, arg18};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
-  if(arg15.idx < -1) {
-    p_a[15] = (char *)op_malloc(-1*args[15].idx*sizeof(T15));
+  if (arg15.idx < -1) {
+    p_a[15] = (char *)op_malloc(-1 * args[15].idx * sizeof(T15));
   }
-  if(arg16.idx < -1) {
-    p_a[16] = (char *)op_malloc(-1*args[16].idx*sizeof(T16));
+  if (arg16.idx < -1) {
+    p_a[16] = (char *)op_malloc(-1 * args[16].idx * sizeof(T16));
   }
-  if(arg17.idx < -1) {
-    p_a[17] = (char *)op_malloc(-1*args[17].idx*sizeof(T17));
+  if (arg17.idx < -1) {
+    p_a[17] = (char *)op_malloc(-1 * args[17].idx * sizeof(T17));
   }
-  if(arg18.idx < -1) {
-    p_a[18] = (char *)op_malloc(-1*args[18].idx*sizeof(T18));
+  if (arg18.idx < -1) {
+    p_a[18] = (char *)op_malloc(-1 * args[18].idx * sizeof(T18));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<19;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 19; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,19,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 19, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -2981,81 +3280,121 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(19,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
-    if (args[15].idx < -1) op_arg_copy_in(n,args[15], (char **)p_a[15]);
-    else op_arg_set(n,args[15], &p_a[15],halo);
-    if (args[16].idx < -1) op_arg_copy_in(n,args[16], (char **)p_a[16]);
-    else op_arg_set(n,args[16], &p_a[16],halo);
-    if (args[17].idx < -1) op_arg_copy_in(n,args[17], (char **)p_a[17]);
-    else op_arg_set(n,args[17], &p_a[17],halo);
-    if (args[18].idx < -1) op_arg_copy_in(n,args[18], (char **)p_a[18]);
-    else op_arg_set(n,args[18], &p_a[18],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(19, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
+    if (args[15].idx < -1)
+      op_arg_copy_in(n, args[15], (char **)p_a[15]);
+    else
+      op_arg_set(n, args[15], &p_a[15], halo);
+    if (args[16].idx < -1)
+      op_arg_copy_in(n, args[16], (char **)p_a[16]);
+    else
+      op_arg_set(n, args[16], &p_a[16], halo);
+    if (args[17].idx < -1)
+      op_arg_copy_in(n, args[17], (char **)p_a[17]);
+    else
+      op_arg_set(n, args[17], &p_a[17], halo);
+    if (args[18].idx < -1)
+      op_arg_copy_in(n, args[18], (char **)p_a[18]);
+    else
+      op_arg_set(n, args[18], &p_a[18], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14], (T15 *)p_a[15],
-          (T16 *)p_a[16], (T17 *)p_a[17], (T18 *)p_a[18]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14], (T15 *)p_a[15], (T16 *)p_a[16], (T17 *)p_a[17],
+           (T18 *)p_a[18]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (19,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(19, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(19, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
-  op_mpi_reduce(&arg15,(T15 *)p_a[15]);
-  op_mpi_reduce(&arg16,(T16 *)p_a[16]);
-  op_mpi_reduce(&arg17,(T17 *)p_a[17]);
-  op_mpi_reduce(&arg18,(T18 *)p_a[18]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
+  op_mpi_reduce(&arg15, (T15 *)p_a[15]);
+  op_mpi_reduce(&arg16, (T16 *)p_a[16]);
+  op_mpi_reduce(&arg17, (T17 *)p_a[17]);
+  op_mpi_reduce(&arg18, (T18 *)p_a[18]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -3066,167 +3405,162 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
-  if(arg15.idx < -1) {
+  if (arg15.idx < -1) {
     free(p_a[15]);
   }
-  if(arg16.idx < -1) {
+  if (arg16.idx < -1) {
     free(p_a[16]);
   }
-  if(arg17.idx < -1) {
+  if (arg17.idx < -1) {
     free(p_a[17]);
   }
-  if(arg18.idx < -1) {
+  if (arg18.idx < -1) {
     free(p_a[18]);
   }
 }
 //
-//op_par_loop routine for 20 arguments
+// op_par_loop routine for 20 arguments
 //
-template <class T0,class T1,class T2,class T3,
-          class T4,class T5,class T6,class T7,
-          class T8,class T9,class T10,class T11,
-          class T12,class T13,class T14,class T15,
-          class T16,class T17,class T18,class T19>
-void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
-                                T4*, T5*, T6*, T7*,
-                                T8*, T9*, T10*, T11*,
-                                T12*, T13*, T14*, T15*,
-                                T16*, T17*, T18*, T19*),
-    char const * name, op_set set,
-    op_arg arg0, op_arg arg1, op_arg arg2, op_arg arg3,
-    op_arg arg4, op_arg arg5, op_arg arg6, op_arg arg7,
-    op_arg arg8, op_arg arg9, op_arg arg10, op_arg arg11,
-    op_arg arg12, op_arg arg13, op_arg arg14, op_arg arg15,
-    op_arg arg16, op_arg arg17, op_arg arg18, op_arg arg19){
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9, class T10, class T11, class T12,
+          class T13, class T14, class T15, class T16, class T17, class T18,
+          class T19>
+void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
+                                T8 *, T9 *, T10 *, T11 *, T12 *, T13 *, T14 *,
+                                T15 *, T16 *, T17 *, T18 *, T19 *),
+                 char const *name, op_set set, op_arg arg0, op_arg arg1,
+                 op_arg arg2, op_arg arg3, op_arg arg4, op_arg arg5,
+                 op_arg arg6, op_arg arg7, op_arg arg8, op_arg arg9,
+                 op_arg arg10, op_arg arg11, op_arg arg12, op_arg arg13,
+                 op_arg arg14, op_arg arg15, op_arg arg16, op_arg arg17,
+                 op_arg arg18, op_arg arg19) {
 
-  char *p_a[20] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  op_arg args[20] = {arg0, arg1, arg2, arg3,
-                    arg4, arg5, arg6, arg7,
-                    arg8, arg9, arg10, arg11,
-                    arg12, arg13, arg14, arg15,
-                    arg16, arg17, arg18, arg19};
-  if(arg0.idx < -1) {
-    p_a[0] = (char *)op_malloc(-1*args[0].idx*sizeof(T0));
+  char *p_a[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  op_arg args[20] = {arg0,  arg1,  arg2,  arg3,  arg4,  arg5,  arg6,
+                     arg7,  arg8,  arg9,  arg10, arg11, arg12, arg13,
+                     arg14, arg15, arg16, arg17, arg18, arg19};
+  if (arg0.idx < -1) {
+    p_a[0] = (char *)op_malloc(-1 * args[0].idx * sizeof(T0));
   }
-  if(arg1.idx < -1) {
-    p_a[1] = (char *)op_malloc(-1*args[1].idx*sizeof(T1));
+  if (arg1.idx < -1) {
+    p_a[1] = (char *)op_malloc(-1 * args[1].idx * sizeof(T1));
   }
-  if(arg2.idx < -1) {
-    p_a[2] = (char *)op_malloc(-1*args[2].idx*sizeof(T2));
+  if (arg2.idx < -1) {
+    p_a[2] = (char *)op_malloc(-1 * args[2].idx * sizeof(T2));
   }
-  if(arg3.idx < -1) {
-    p_a[3] = (char *)op_malloc(-1*args[3].idx*sizeof(T3));
+  if (arg3.idx < -1) {
+    p_a[3] = (char *)op_malloc(-1 * args[3].idx * sizeof(T3));
   }
-  if(arg4.idx < -1) {
-    p_a[4] = (char *)op_malloc(-1*args[4].idx*sizeof(T4));
+  if (arg4.idx < -1) {
+    p_a[4] = (char *)op_malloc(-1 * args[4].idx * sizeof(T4));
   }
-  if(arg5.idx < -1) {
-    p_a[5] = (char *)op_malloc(-1*args[5].idx*sizeof(T5));
+  if (arg5.idx < -1) {
+    p_a[5] = (char *)op_malloc(-1 * args[5].idx * sizeof(T5));
   }
-  if(arg6.idx < -1) {
-    p_a[6] = (char *)op_malloc(-1*args[6].idx*sizeof(T6));
+  if (arg6.idx < -1) {
+    p_a[6] = (char *)op_malloc(-1 * args[6].idx * sizeof(T6));
   }
-  if(arg7.idx < -1) {
-    p_a[7] = (char *)op_malloc(-1*args[7].idx*sizeof(T7));
+  if (arg7.idx < -1) {
+    p_a[7] = (char *)op_malloc(-1 * args[7].idx * sizeof(T7));
   }
-  if(arg8.idx < -1) {
-    p_a[8] = (char *)op_malloc(-1*args[8].idx*sizeof(T8));
+  if (arg8.idx < -1) {
+    p_a[8] = (char *)op_malloc(-1 * args[8].idx * sizeof(T8));
   }
-  if(arg9.idx < -1) {
-    p_a[9] = (char *)op_malloc(-1*args[9].idx*sizeof(T9));
+  if (arg9.idx < -1) {
+    p_a[9] = (char *)op_malloc(-1 * args[9].idx * sizeof(T9));
   }
-  if(arg10.idx < -1) {
-    p_a[10] = (char *)op_malloc(-1*args[10].idx*sizeof(T10));
+  if (arg10.idx < -1) {
+    p_a[10] = (char *)op_malloc(-1 * args[10].idx * sizeof(T10));
   }
-  if(arg11.idx < -1) {
-    p_a[11] = (char *)op_malloc(-1*args[11].idx*sizeof(T11));
+  if (arg11.idx < -1) {
+    p_a[11] = (char *)op_malloc(-1 * args[11].idx * sizeof(T11));
   }
-  if(arg12.idx < -1) {
-    p_a[12] = (char *)op_malloc(-1*args[12].idx*sizeof(T12));
+  if (arg12.idx < -1) {
+    p_a[12] = (char *)op_malloc(-1 * args[12].idx * sizeof(T12));
   }
-  if(arg13.idx < -1) {
-    p_a[13] = (char *)op_malloc(-1*args[13].idx*sizeof(T13));
+  if (arg13.idx < -1) {
+    p_a[13] = (char *)op_malloc(-1 * args[13].idx * sizeof(T13));
   }
-  if(arg14.idx < -1) {
-    p_a[14] = (char *)op_malloc(-1*args[14].idx*sizeof(T14));
+  if (arg14.idx < -1) {
+    p_a[14] = (char *)op_malloc(-1 * args[14].idx * sizeof(T14));
   }
-  if(arg15.idx < -1) {
-    p_a[15] = (char *)op_malloc(-1*args[15].idx*sizeof(T15));
+  if (arg15.idx < -1) {
+    p_a[15] = (char *)op_malloc(-1 * args[15].idx * sizeof(T15));
   }
-  if(arg16.idx < -1) {
-    p_a[16] = (char *)op_malloc(-1*args[16].idx*sizeof(T16));
+  if (arg16.idx < -1) {
+    p_a[16] = (char *)op_malloc(-1 * args[16].idx * sizeof(T16));
   }
-  if(arg17.idx < -1) {
-    p_a[17] = (char *)op_malloc(-1*args[17].idx*sizeof(T17));
+  if (arg17.idx < -1) {
+    p_a[17] = (char *)op_malloc(-1 * args[17].idx * sizeof(T17));
   }
-  if(arg18.idx < -1) {
-    p_a[18] = (char *)op_malloc(-1*args[18].idx*sizeof(T18));
+  if (arg18.idx < -1) {
+    p_a[18] = (char *)op_malloc(-1 * args[18].idx * sizeof(T18));
   }
-  if(arg19.idx < -1) {
-    p_a[19] = (char *)op_malloc(-1*args[19].idx*sizeof(T19));
+  if (arg19.idx < -1) {
+    p_a[19] = (char *)op_malloc(-1 * args[19].idx * sizeof(T19));
   }
 
-  //allocate scratch mememory to do double counting in indirect reduction
-  for (int i = 0; i<20;i++)
-    if(args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size )
-    {
+  // allocate scratch mememory to do double counting in indirect reduction
+  for (int i = 0; i < 20; i++)
+    if (args[i].argtype == OP_ARG_GBL && args[i].size > blank_args_size) {
       blank_args_size = args[i].size;
       blank_args = (char *)op_malloc(blank_args_size);
     }
   // consistency checks
   int ninds = 0;
-  if (OP_diags>0) op_args_check(set,20,args,&ninds,name);
+  if (OP_diags > 0)
+    op_args_check(set, 20, args, &ninds, name);
 
-  if (OP_diags>2) {
-  if (ninds==0)
-    printf(" kernel routine w/o indirection:  %s\n",name);
-  else
-    printf(" kernel routine with indirection: %s\n",name);
+  if (OP_diags > 2) {
+    if (ninds == 0)
+      printf(" kernel routine w/o indirection:  %s\n", name);
+    else
+      printf(" kernel routine with indirection: %s\n", name);
   }
   // initialise timers
   double cpu_t1, cpu_t2, wall_t1, wall_t2;
@@ -3238,84 +3572,126 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   // loop over set elements
   int halo = 0;
 
-  for (int n=0; n<n_upper; n++) {
-    if (n==set->core_size) op_mpi_wait_all(20,args);
-    if (n==set->size) halo = 1;
-    if (args[0].idx < -1) op_arg_copy_in(n,args[0], (char **)p_a[0]);
-    else op_arg_set(n,args[0], &p_a[0],halo);
-    if (args[1].idx < -1) op_arg_copy_in(n,args[1], (char **)p_a[1]);
-    else op_arg_set(n,args[1], &p_a[1],halo);
-    if (args[2].idx < -1) op_arg_copy_in(n,args[2], (char **)p_a[2]);
-    else op_arg_set(n,args[2], &p_a[2],halo);
-    if (args[3].idx < -1) op_arg_copy_in(n,args[3], (char **)p_a[3]);
-    else op_arg_set(n,args[3], &p_a[3],halo);
-    if (args[4].idx < -1) op_arg_copy_in(n,args[4], (char **)p_a[4]);
-    else op_arg_set(n,args[4], &p_a[4],halo);
-    if (args[5].idx < -1) op_arg_copy_in(n,args[5], (char **)p_a[5]);
-    else op_arg_set(n,args[5], &p_a[5],halo);
-    if (args[6].idx < -1) op_arg_copy_in(n,args[6], (char **)p_a[6]);
-    else op_arg_set(n,args[6], &p_a[6],halo);
-    if (args[7].idx < -1) op_arg_copy_in(n,args[7], (char **)p_a[7]);
-    else op_arg_set(n,args[7], &p_a[7],halo);
-    if (args[8].idx < -1) op_arg_copy_in(n,args[8], (char **)p_a[8]);
-    else op_arg_set(n,args[8], &p_a[8],halo);
-    if (args[9].idx < -1) op_arg_copy_in(n,args[9], (char **)p_a[9]);
-    else op_arg_set(n,args[9], &p_a[9],halo);
-    if (args[10].idx < -1) op_arg_copy_in(n,args[10], (char **)p_a[10]);
-    else op_arg_set(n,args[10], &p_a[10],halo);
-    if (args[11].idx < -1) op_arg_copy_in(n,args[11], (char **)p_a[11]);
-    else op_arg_set(n,args[11], &p_a[11],halo);
-    if (args[12].idx < -1) op_arg_copy_in(n,args[12], (char **)p_a[12]);
-    else op_arg_set(n,args[12], &p_a[12],halo);
-    if (args[13].idx < -1) op_arg_copy_in(n,args[13], (char **)p_a[13]);
-    else op_arg_set(n,args[13], &p_a[13],halo);
-    if (args[14].idx < -1) op_arg_copy_in(n,args[14], (char **)p_a[14]);
-    else op_arg_set(n,args[14], &p_a[14],halo);
-    if (args[15].idx < -1) op_arg_copy_in(n,args[15], (char **)p_a[15]);
-    else op_arg_set(n,args[15], &p_a[15],halo);
-    if (args[16].idx < -1) op_arg_copy_in(n,args[16], (char **)p_a[16]);
-    else op_arg_set(n,args[16], &p_a[16],halo);
-    if (args[17].idx < -1) op_arg_copy_in(n,args[17], (char **)p_a[17]);
-    else op_arg_set(n,args[17], &p_a[17],halo);
-    if (args[18].idx < -1) op_arg_copy_in(n,args[18], (char **)p_a[18]);
-    else op_arg_set(n,args[18], &p_a[18],halo);
-    if (args[19].idx < -1) op_arg_copy_in(n,args[19], (char **)p_a[19]);
-    else op_arg_set(n,args[19], &p_a[19],halo);
+  for (int n = 0; n < n_upper; n++) {
+    if (n == set->core_size)
+      op_mpi_wait_all(20, args);
+    if (n == set->size)
+      halo = 1;
+    if (args[0].idx < -1)
+      op_arg_copy_in(n, args[0], (char **)p_a[0]);
+    else
+      op_arg_set(n, args[0], &p_a[0], halo);
+    if (args[1].idx < -1)
+      op_arg_copy_in(n, args[1], (char **)p_a[1]);
+    else
+      op_arg_set(n, args[1], &p_a[1], halo);
+    if (args[2].idx < -1)
+      op_arg_copy_in(n, args[2], (char **)p_a[2]);
+    else
+      op_arg_set(n, args[2], &p_a[2], halo);
+    if (args[3].idx < -1)
+      op_arg_copy_in(n, args[3], (char **)p_a[3]);
+    else
+      op_arg_set(n, args[3], &p_a[3], halo);
+    if (args[4].idx < -1)
+      op_arg_copy_in(n, args[4], (char **)p_a[4]);
+    else
+      op_arg_set(n, args[4], &p_a[4], halo);
+    if (args[5].idx < -1)
+      op_arg_copy_in(n, args[5], (char **)p_a[5]);
+    else
+      op_arg_set(n, args[5], &p_a[5], halo);
+    if (args[6].idx < -1)
+      op_arg_copy_in(n, args[6], (char **)p_a[6]);
+    else
+      op_arg_set(n, args[6], &p_a[6], halo);
+    if (args[7].idx < -1)
+      op_arg_copy_in(n, args[7], (char **)p_a[7]);
+    else
+      op_arg_set(n, args[7], &p_a[7], halo);
+    if (args[8].idx < -1)
+      op_arg_copy_in(n, args[8], (char **)p_a[8]);
+    else
+      op_arg_set(n, args[8], &p_a[8], halo);
+    if (args[9].idx < -1)
+      op_arg_copy_in(n, args[9], (char **)p_a[9]);
+    else
+      op_arg_set(n, args[9], &p_a[9], halo);
+    if (args[10].idx < -1)
+      op_arg_copy_in(n, args[10], (char **)p_a[10]);
+    else
+      op_arg_set(n, args[10], &p_a[10], halo);
+    if (args[11].idx < -1)
+      op_arg_copy_in(n, args[11], (char **)p_a[11]);
+    else
+      op_arg_set(n, args[11], &p_a[11], halo);
+    if (args[12].idx < -1)
+      op_arg_copy_in(n, args[12], (char **)p_a[12]);
+    else
+      op_arg_set(n, args[12], &p_a[12], halo);
+    if (args[13].idx < -1)
+      op_arg_copy_in(n, args[13], (char **)p_a[13]);
+    else
+      op_arg_set(n, args[13], &p_a[13], halo);
+    if (args[14].idx < -1)
+      op_arg_copy_in(n, args[14], (char **)p_a[14]);
+    else
+      op_arg_set(n, args[14], &p_a[14], halo);
+    if (args[15].idx < -1)
+      op_arg_copy_in(n, args[15], (char **)p_a[15]);
+    else
+      op_arg_set(n, args[15], &p_a[15], halo);
+    if (args[16].idx < -1)
+      op_arg_copy_in(n, args[16], (char **)p_a[16]);
+    else
+      op_arg_set(n, args[16], &p_a[16], halo);
+    if (args[17].idx < -1)
+      op_arg_copy_in(n, args[17], (char **)p_a[17]);
+    else
+      op_arg_set(n, args[17], &p_a[17], halo);
+    if (args[18].idx < -1)
+      op_arg_copy_in(n, args[18], (char **)p_a[18]);
+    else
+      op_arg_set(n, args[18], &p_a[18], halo);
+    if (args[19].idx < -1)
+      op_arg_copy_in(n, args[19], (char **)p_a[19]);
+    else
+      op_arg_set(n, args[19], &p_a[19], halo);
 
-    kernel( (T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3],
-          (T4 *)p_a[4], (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7],
-          (T8 *)p_a[8], (T9 *)p_a[9], (T10 *)p_a[10], (T11 *)p_a[11],
-          (T12 *)p_a[12], (T13 *)p_a[13], (T14 *)p_a[14], (T15 *)p_a[15],
-          (T16 *)p_a[16], (T17 *)p_a[17], (T18 *)p_a[18], (T19 *)p_a[19]);
+    kernel((T0 *)p_a[0], (T1 *)p_a[1], (T2 *)p_a[2], (T3 *)p_a[3], (T4 *)p_a[4],
+           (T5 *)p_a[5], (T6 *)p_a[6], (T7 *)p_a[7], (T8 *)p_a[8], (T9 *)p_a[9],
+           (T10 *)p_a[10], (T11 *)p_a[11], (T12 *)p_a[12], (T13 *)p_a[13],
+           (T14 *)p_a[14], (T15 *)p_a[15], (T16 *)p_a[16], (T17 *)p_a[17],
+           (T18 *)p_a[18], (T19 *)p_a[19]);
   }
-  if ( n_upper == set->core_size || n_upper == 0 )
-    op_mpi_wait_all (20,args);
+  if (n_upper == set->core_size || n_upper == 0)
+    op_mpi_wait_all(20, args);
 
-  //set dirty bit on datasets touched
+  // set dirty bit on datasets touched
   op_mpi_set_dirtybit(20, args);
 
-  //global reduction for MPI execution, if needed
-  //p_a simply used to determine type for MPI reduction
-  op_mpi_reduce(&arg0,(T0 *)p_a[0]);
-  op_mpi_reduce(&arg1,(T1 *)p_a[1]);
-  op_mpi_reduce(&arg2,(T2 *)p_a[2]);
-  op_mpi_reduce(&arg3,(T3 *)p_a[3]);
-  op_mpi_reduce(&arg4,(T4 *)p_a[4]);
-  op_mpi_reduce(&arg5,(T5 *)p_a[5]);
-  op_mpi_reduce(&arg6,(T6 *)p_a[6]);
-  op_mpi_reduce(&arg7,(T7 *)p_a[7]);
-  op_mpi_reduce(&arg8,(T8 *)p_a[8]);
-  op_mpi_reduce(&arg9,(T9 *)p_a[9]);
-  op_mpi_reduce(&arg10,(T10 *)p_a[10]);
-  op_mpi_reduce(&arg11,(T11 *)p_a[11]);
-  op_mpi_reduce(&arg12,(T12 *)p_a[12]);
-  op_mpi_reduce(&arg13,(T13 *)p_a[13]);
-  op_mpi_reduce(&arg14,(T14 *)p_a[14]);
-  op_mpi_reduce(&arg15,(T15 *)p_a[15]);
-  op_mpi_reduce(&arg16,(T16 *)p_a[16]);
-  op_mpi_reduce(&arg17,(T17 *)p_a[17]);
-  op_mpi_reduce(&arg18,(T18 *)p_a[18]);
-  op_mpi_reduce(&arg19,(T19 *)p_a[19]);
+  // global reduction for MPI execution, if needed
+  // p_a simply used to determine type for MPI reduction
+  op_mpi_reduce(&arg0, (T0 *)p_a[0]);
+  op_mpi_reduce(&arg1, (T1 *)p_a[1]);
+  op_mpi_reduce(&arg2, (T2 *)p_a[2]);
+  op_mpi_reduce(&arg3, (T3 *)p_a[3]);
+  op_mpi_reduce(&arg4, (T4 *)p_a[4]);
+  op_mpi_reduce(&arg5, (T5 *)p_a[5]);
+  op_mpi_reduce(&arg6, (T6 *)p_a[6]);
+  op_mpi_reduce(&arg7, (T7 *)p_a[7]);
+  op_mpi_reduce(&arg8, (T8 *)p_a[8]);
+  op_mpi_reduce(&arg9, (T9 *)p_a[9]);
+  op_mpi_reduce(&arg10, (T10 *)p_a[10]);
+  op_mpi_reduce(&arg11, (T11 *)p_a[11]);
+  op_mpi_reduce(&arg12, (T12 *)p_a[12]);
+  op_mpi_reduce(&arg13, (T13 *)p_a[13]);
+  op_mpi_reduce(&arg14, (T14 *)p_a[14]);
+  op_mpi_reduce(&arg15, (T15 *)p_a[15]);
+  op_mpi_reduce(&arg16, (T16 *)p_a[16]);
+  op_mpi_reduce(&arg17, (T17 *)p_a[17]);
+  op_mpi_reduce(&arg18, (T18 *)p_a[18]);
+  op_mpi_reduce(&arg19, (T19 *)p_a[19]);
 
   // update timer record
   op_timers_core(&cpu_t2, &wall_t2);
@@ -3326,64 +3702,64 @@ void op_par_loop(void (*kernel)(T0*, T1*, T2*, T3*,
   op_mpi_perf_time(name, wall_t2 - wall_t1);
 #endif
 
-  if(arg0.idx < -1) {
+  if (arg0.idx < -1) {
     free(p_a[0]);
   }
-  if(arg1.idx < -1) {
+  if (arg1.idx < -1) {
     free(p_a[1]);
   }
-  if(arg2.idx < -1) {
+  if (arg2.idx < -1) {
     free(p_a[2]);
   }
-  if(arg3.idx < -1) {
+  if (arg3.idx < -1) {
     free(p_a[3]);
   }
-  if(arg4.idx < -1) {
+  if (arg4.idx < -1) {
     free(p_a[4]);
   }
-  if(arg5.idx < -1) {
+  if (arg5.idx < -1) {
     free(p_a[5]);
   }
-  if(arg6.idx < -1) {
+  if (arg6.idx < -1) {
     free(p_a[6]);
   }
-  if(arg7.idx < -1) {
+  if (arg7.idx < -1) {
     free(p_a[7]);
   }
-  if(arg8.idx < -1) {
+  if (arg8.idx < -1) {
     free(p_a[8]);
   }
-  if(arg9.idx < -1) {
+  if (arg9.idx < -1) {
     free(p_a[9]);
   }
-  if(arg10.idx < -1) {
+  if (arg10.idx < -1) {
     free(p_a[10]);
   }
-  if(arg11.idx < -1) {
+  if (arg11.idx < -1) {
     free(p_a[11]);
   }
-  if(arg12.idx < -1) {
+  if (arg12.idx < -1) {
     free(p_a[12]);
   }
-  if(arg13.idx < -1) {
+  if (arg13.idx < -1) {
     free(p_a[13]);
   }
-  if(arg14.idx < -1) {
+  if (arg14.idx < -1) {
     free(p_a[14]);
   }
-  if(arg15.idx < -1) {
+  if (arg15.idx < -1) {
     free(p_a[15]);
   }
-  if(arg16.idx < -1) {
+  if (arg16.idx < -1) {
     free(p_a[16]);
   }
-  if(arg17.idx < -1) {
+  if (arg17.idx < -1) {
     free(p_a[17]);
   }
-  if(arg18.idx < -1) {
+  if (arg18.idx < -1) {
     free(p_a[18]);
   }
-  if(arg19.idx < -1) {
+  if (arg19.idx < -1) {
     free(p_a[19]);
   }
 }

--- a/op2/c/include/op_util.h
+++ b/op2/c/include/op_util.h
@@ -41,8 +41,6 @@
  * written by: Gihan R. Mudalige, (Started 01-03-2011)
  */
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,13 +49,13 @@ extern "C" {
 * MPI utility function prototypes
 *******************************************************************************/
 
-int compute_local_size (int global_size, int mpi_comm_size, int mpi_rank );
+int compute_local_size(int global_size, int mpi_comm_size, int mpi_rank);
 
-void* xmalloc(size_t size);
+void *xmalloc(size_t size);
 
-void* xcalloc(size_t number, size_t size);
+void *xcalloc(size_t number, size_t size);
 
-void* xrealloc(void *ptr, size_t size);
+void *xrealloc(void *ptr, size_t size);
 
 int compare_sets(op_set set1, op_set set2);
 
@@ -88,4 +86,3 @@ bool op_type_equivalence(const char *a, const char *b);
 #endif
 
 #endif /* __OP_UTIL_H */
-

--- a/op2/c/include/uthash.h
+++ b/op2/c/include/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2013, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2003-2013, Troy D. Hanson http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,36 +24,36 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTHASH_H
 #define UTHASH_H
 
-#include <string.h>   /* memcmp,strlen */
-#include <stddef.h>   /* ptrdiff_t */
-#include <stdlib.h>   /* exit() */
+#include <stddef.h> /* ptrdiff_t */
+#include <stdlib.h> /* exit() */
+#include <string.h> /* memcmp,strlen */
 
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
    or, for VS2008 where neither is available, uses casting workarounds. */
-#ifdef _MSC_VER         /* MS compiler */
-#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#ifdef _MSC_VER                              /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus) /* VS2010 or newer in C++ mode */
 #define DECLTYPE(x) (decltype(x))
-#else                   /* VS2008 or older (or VS2010 in C mode) */
+#else /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #define DECLTYPE(x)
 #endif
-#else                   /* GNU, Sun and other compilers */
+#else /* GNU, Sun and other compilers */
 #define DECLTYPE(x) (__typeof(x))
 #endif
 
 #ifdef NO_DECLTYPE
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  char **_da_dst = (char**)(&(dst));                                             \
-  *_da_dst = (char*)(src);                                                       \
-} while(0)
+#define DECLTYPE_ASSIGN(dst, src)                                              \
+  do {                                                                         \
+    char **_da_dst = (char **)(&(dst));                                        \
+    *_da_dst = (char *)(src);                                                  \
+  } while (0)
 #else
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  (dst) = DECLTYPE(dst)(src);                                                    \
-} while(0)
+#define DECLTYPE_ASSIGN(dst, src)                                              \
+  do {                                                                         \
+    (dst) = DECLTYPE(dst)(src);                                                \
+  } while (0)
 #endif
 
 /* a number of the hash function use uint32_t which isn't defined on win32 */
@@ -61,144 +61,153 @@ do {                                                                            
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
 #else
-#include <inttypes.h>   /* uint32_t */
+#include <inttypes.h> /* uint32_t */
 #endif
 
 #define UTHASH_VERSION 1.9.8
 
 #ifndef uthash_fatal
-#define uthash_fatal(msg) exit(-1)        /* fatal error (out of memory,etc) */
+#define uthash_fatal(msg) exit(-1) /* fatal error (out of memory,etc) */
 #endif
 #ifndef uthash_malloc
-#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#define uthash_malloc(sz) malloc(sz) /* malloc fcn                      */
 #endif
 #ifndef uthash_free
-#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#define uthash_free(ptr, sz) free(ptr) /* free fcn                        */
 #endif
 
 #ifndef uthash_noexpand_fyi
-#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#define uthash_noexpand_fyi(tbl) /* can be defined to log noexpand  */
 #endif
 #ifndef uthash_expand_fyi
-#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#define uthash_expand_fyi(tbl) /* can be defined to log expands   */
 #endif
 
 /* initial number of buckets */
-#define HASH_INITIAL_NUM_BUCKETS 32      /* initial number of buckets        */
-#define HASH_INITIAL_NUM_BUCKETS_LOG2 5  /* lg2 of initial number of buckets */
-#define HASH_BKT_CAPACITY_THRESH 10      /* expand when bucket count reaches */
+#define HASH_INITIAL_NUM_BUCKETS 32     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5 /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10     /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhe */
-#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+#define ELMT_FROM_HH(tbl, hhp) ((void *)(((char *)(hhp)) - ((tbl)->hho)))
 
-#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
-do {                                                                             \
-  unsigned _hf_bkt,_hf_hashv;                                                    \
-  out=NULL;                                                                      \
-  if (head) {                                                                    \
-     HASH_FCN(keyptr,keylen, (head)->hh.tbl->num_buckets, _hf_hashv, _hf_bkt);   \
-     if (HASH_BLOOM_TEST((head)->hh.tbl, _hf_hashv)) {                           \
-       HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ],  \
-                        keyptr,keylen,out);                                      \
-     }                                                                           \
-  }                                                                              \
-} while (0)
+#define HASH_FIND(hh, head, keyptr, keylen, out)                               \
+  do {                                                                         \
+    unsigned _hf_bkt, _hf_hashv;                                               \
+    out = NULL;                                                                \
+    if (head) {                                                                \
+      HASH_FCN(keyptr, keylen, (head)->hh.tbl->num_buckets, _hf_hashv,         \
+               _hf_bkt);                                                       \
+      if (HASH_BLOOM_TEST((head)->hh.tbl, _hf_hashv)) {                        \
+        HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[_hf_bkt], \
+                         keyptr, keylen, out);                                 \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
 
 #ifdef HASH_BLOOM
 #define HASH_BLOOM_BITLEN (1ULL << HASH_BLOOM)
-#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8) + ((HASH_BLOOM_BITLEN%8) ? 1:0)
-#define HASH_BLOOM_MAKE(tbl)                                                     \
-do {                                                                             \
-  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
-  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
-  if (!((tbl)->bloom_bv))  { uthash_fatal( "out of memory"); }                   \
-  memset((tbl)->bloom_bv, 0, HASH_BLOOM_BYTELEN);                                \
-  (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                       \
-} while (0)
+#define HASH_BLOOM_BYTELEN                                                     \
+  (HASH_BLOOM_BITLEN / 8) + ((HASH_BLOOM_BITLEN % 8) ? 1 : 0)
+#define HASH_BLOOM_MAKE(tbl)                                                   \
+  do {                                                                         \
+    (tbl)->bloom_nbits = HASH_BLOOM;                                           \
+    (tbl)->bloom_bv = (uint8_t *)uthash_malloc(HASH_BLOOM_BYTELEN);            \
+    if (!((tbl)->bloom_bv)) {                                                  \
+      uthash_fatal("out of memory");                                           \
+    }                                                                          \
+    memset((tbl)->bloom_bv, 0, HASH_BLOOM_BYTELEN);                            \
+    (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                   \
+  } while (0)
 
-#define HASH_BLOOM_FREE(tbl)                                                     \
-do {                                                                             \
-  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
-} while (0)
+#define HASH_BLOOM_FREE(tbl)                                                   \
+  do {                                                                         \
+    uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                          \
+  } while (0)
 
-#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8] |= (1U << ((idx)%8)))
-#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8] & (1U << ((idx)%8)))
+#define HASH_BLOOM_BITSET(bv, idx) (bv[(idx) / 8] |= (1U << ((idx) % 8)))
+#define HASH_BLOOM_BITTEST(bv, idx) (bv[(idx) / 8] & (1U << ((idx) % 8)))
 
-#define HASH_BLOOM_ADD(tbl,hashv)                                                \
-  HASH_BLOOM_BITSET((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+#define HASH_BLOOM_ADD(tbl, hashv)                                             \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv,                                           \
+                    (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
 
-#define HASH_BLOOM_TEST(tbl,hashv)                                               \
-  HASH_BLOOM_BITTEST((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+#define HASH_BLOOM_TEST(tbl, hashv)                                            \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv,                                          \
+                     (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
 
 #else
 #define HASH_BLOOM_MAKE(tbl)
 #define HASH_BLOOM_FREE(tbl)
-#define HASH_BLOOM_ADD(tbl,hashv)
-#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#define HASH_BLOOM_ADD(tbl, hashv)
+#define HASH_BLOOM_TEST(tbl, hashv) (1)
 #define HASH_BLOOM_BYTELEN 0
 #endif
 
-#define HASH_MAKE_TABLE(hh,head)                                                 \
-do {                                                                             \
-  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(                                \
-                  sizeof(UT_hash_table));                                        \
-  if (!((head)->hh.tbl))  { uthash_fatal( "out of memory"); }                    \
-  memset((head)->hh.tbl, 0, sizeof(UT_hash_table));                              \
-  (head)->hh.tbl->tail = &((head)->hh);                                          \
-  (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                        \
-  (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;              \
-  (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                    \
-  (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                      \
-          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
-  if (! (head)->hh.tbl->buckets) { uthash_fatal( "out of memory"); }             \
-  memset((head)->hh.tbl->buckets, 0,                                             \
-          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
-  HASH_BLOOM_MAKE((head)->hh.tbl);                                               \
-  (head)->hh.tbl->signature = HASH_SIGNATURE;                                    \
-} while(0)
+#define HASH_MAKE_TABLE(hh, head)                                              \
+  do {                                                                         \
+    (head)->hh.tbl = (UT_hash_table *)uthash_malloc(sizeof(UT_hash_table));    \
+    if (!((head)->hh.tbl)) {                                                   \
+      uthash_fatal("out of memory");                                           \
+    }                                                                          \
+    memset((head)->hh.tbl, 0, sizeof(UT_hash_table));                          \
+    (head)->hh.tbl->tail = &((head)->hh);                                      \
+    (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                    \
+    (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;          \
+    (head)->hh.tbl->hho = (char *)(&(head)->hh) - (char *)(head);              \
+    (head)->hh.tbl->buckets = (UT_hash_bucket *)uthash_malloc(                 \
+        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));             \
+    if (!(head)->hh.tbl->buckets) {                                            \
+      uthash_fatal("out of memory");                                           \
+    }                                                                          \
+    memset((head)->hh.tbl->buckets, 0,                                         \
+           HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));          \
+    HASH_BLOOM_MAKE((head)->hh.tbl);                                           \
+    (head)->hh.tbl->signature = HASH_SIGNATURE;                                \
+  } while (0)
 
-#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
-        HASH_ADD_KEYPTR(hh,head,&((add)->fieldname),keylen_in,add)
+#define HASH_ADD(hh, head, fieldname, keylen_in, add)                          \
+  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
 
-#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
-do {                                                                             \
-  replaced=NULL;                                                                 \
-  HASH_FIND(hh,head,&((add)->fieldname),keylen_in,replaced);                     \
-  if (replaced!=NULL) {                                                          \
-     HASH_DELETE(hh,head,replaced);                                              \
-  };                                                                             \
-  HASH_ADD(hh,head,fieldname,keylen_in,add);                                     \
-} while(0)
+#define HASH_REPLACE(hh, head, fieldname, keylen_in, add, replaced)            \
+  do {                                                                         \
+    replaced = NULL;                                                           \
+    HASH_FIND(hh, head, &((add)->fieldname), keylen_in, replaced);             \
+    if (replaced != NULL) {                                                    \
+      HASH_DELETE(hh, head, replaced);                                         \
+    };                                                                         \
+    HASH_ADD(hh, head, fieldname, keylen_in, add);                             \
+  } while (0)
 
-#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
-do {                                                                             \
- unsigned _ha_bkt;                                                               \
- (add)->hh.next = NULL;                                                          \
- (add)->hh.key = (char*)keyptr;                                                  \
- (add)->hh.keylen = (unsigned)keylen_in;                                                   \
- if (!(head)) {                                                                  \
-    head = (add);                                                                \
-    (head)->hh.prev = NULL;                                                      \
-    HASH_MAKE_TABLE(hh,head);                                                    \
- } else {                                                                        \
-    (head)->hh.tbl->tail->next = (add);                                          \
-    (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);         \
-    (head)->hh.tbl->tail = &((add)->hh);                                         \
- }                                                                               \
- (head)->hh.tbl->num_items++;                                                    \
- (add)->hh.tbl = (head)->hh.tbl;                                                 \
- HASH_FCN(keyptr,keylen_in, (head)->hh.tbl->num_buckets,                         \
-         (add)->hh.hashv, _ha_bkt);                                              \
- HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt],&(add)->hh);                   \
- HASH_BLOOM_ADD((head)->hh.tbl,(add)->hh.hashv);                                 \
- HASH_EMIT_KEY(hh,head,keyptr,keylen_in);                                        \
- HASH_FSCK(hh,head);                                                             \
-} while(0)
+#define HASH_ADD_KEYPTR(hh, head, keyptr, keylen_in, add)                      \
+  do {                                                                         \
+    unsigned _ha_bkt;                                                          \
+    (add)->hh.next = NULL;                                                     \
+    (add)->hh.key = (char *)keyptr;                                            \
+    (add)->hh.keylen = (unsigned)keylen_in;                                    \
+    if (!(head)) {                                                             \
+      head = (add);                                                            \
+      (head)->hh.prev = NULL;                                                  \
+      HASH_MAKE_TABLE(hh, head);                                               \
+    } else {                                                                   \
+      (head)->hh.tbl->tail->next = (add);                                      \
+      (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);     \
+      (head)->hh.tbl->tail = &((add)->hh);                                     \
+    }                                                                          \
+    (head)->hh.tbl->num_items++;                                               \
+    (add)->hh.tbl = (head)->hh.tbl;                                            \
+    HASH_FCN(keyptr, keylen_in, (head)->hh.tbl->num_buckets, (add)->hh.hashv,  \
+             _ha_bkt);                                                         \
+    HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], &(add)->hh);             \
+    HASH_BLOOM_ADD((head)->hh.tbl, (add)->hh.hashv);                           \
+    HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                \
+    HASH_FSCK(hh, head);                                                       \
+  } while (0)
 
-#define HASH_TO_BKT( hashv, num_bkts, bkt )                                      \
-do {                                                                             \
-  bkt = ((hashv) & ((num_bkts) - 1));                                            \
-} while(0)
+#define HASH_TO_BKT(hashv, num_bkts, bkt)                                      \
+  do {                                                                         \
+    bkt = ((hashv) & ((num_bkts)-1));                                          \
+  } while (0)
 
 /* delete "delptr" from the hash table.
  * "the usual" patch-up process for the app-order doubly-linked-list.
@@ -212,136 +221,141 @@ do {                                                                            
  * copy the deletee pointer, then the latter references are via that
  * scratch pointer rather than through the repointed (users) symbol.
  */
-#define HASH_DELETE(hh,head,delptr)                                              \
-do {                                                                             \
-    unsigned _hd_bkt;                                                            \
-    struct UT_hash_handle *_hd_hh_del;                                           \
-    if ( ((delptr)->hh.prev == NULL) && ((delptr)->hh.next == NULL) )  {         \
-        uthash_free((head)->hh.tbl->buckets,                                     \
-                    (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
-        HASH_BLOOM_FREE((head)->hh.tbl);                                         \
-        uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
-        head = NULL;                                                             \
-    } else {                                                                     \
-        _hd_hh_del = &((delptr)->hh);                                            \
-        if ((delptr) == ELMT_FROM_HH((head)->hh.tbl,(head)->hh.tbl->tail)) {     \
-            (head)->hh.tbl->tail =                                               \
-                (UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +               \
-                (head)->hh.tbl->hho);                                            \
-        }                                                                        \
-        if ((delptr)->hh.prev) {                                                 \
-            ((UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +                  \
-                    (head)->hh.tbl->hho))->next = (delptr)->hh.next;             \
-        } else {                                                                 \
-            DECLTYPE_ASSIGN(head,(delptr)->hh.next);                             \
-        }                                                                        \
-        if (_hd_hh_del->next) {                                                  \
-            ((UT_hash_handle*)((ptrdiff_t)_hd_hh_del->next +                     \
-                    (head)->hh.tbl->hho))->prev =                                \
-                    _hd_hh_del->prev;                                            \
-        }                                                                        \
-        HASH_TO_BKT( _hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);   \
-        HASH_DEL_IN_BKT(hh,(head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);        \
-        (head)->hh.tbl->num_items--;                                             \
-    }                                                                            \
-    HASH_FSCK(hh,head);                                                          \
-} while (0)
-
+#define HASH_DELETE(hh, head, delptr)                                          \
+  do {                                                                         \
+    unsigned _hd_bkt;                                                          \
+    struct UT_hash_handle *_hd_hh_del;                                         \
+    if (((delptr)->hh.prev == NULL) && ((delptr)->hh.next == NULL)) {          \
+      uthash_free((head)->hh.tbl->buckets, (head)->hh.tbl->num_buckets *       \
+                                               sizeof(struct UT_hash_bucket)); \
+      HASH_BLOOM_FREE((head)->hh.tbl);                                         \
+      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
+      head = NULL;                                                             \
+    } else {                                                                   \
+      _hd_hh_del = &((delptr)->hh);                                            \
+      if ((delptr) == ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail)) {    \
+        (head)->hh.tbl->tail =                                                 \
+            (UT_hash_handle *)((ptrdiff_t)((delptr)->hh.prev) +                \
+                               (head)->hh.tbl->hho);                           \
+      }                                                                        \
+      if ((delptr)->hh.prev) {                                                 \
+        ((UT_hash_handle *)((ptrdiff_t)((delptr)->hh.prev) +                   \
+                            (head)->hh.tbl->hho))                              \
+            ->next = (delptr)->hh.next;                                        \
+      } else {                                                                 \
+        DECLTYPE_ASSIGN(head, (delptr)->hh.next);                              \
+      }                                                                        \
+      if (_hd_hh_del->next) {                                                  \
+        ((UT_hash_handle *)((ptrdiff_t)_hd_hh_del->next +                      \
+                            (head)->hh.tbl->hho))                              \
+            ->prev = _hd_hh_del->prev;                                         \
+      }                                                                        \
+      HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);    \
+      HASH_DEL_IN_BKT(hh, (head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);       \
+      (head)->hh.tbl->num_items--;                                             \
+    }                                                                          \
+    HASH_FSCK(hh, head);                                                       \
+  } while (0)
 
 /* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
-#define HASH_FIND_STR(head,findstr,out)                                          \
-    HASH_FIND(hh,head,findstr,strlen(findstr),out)
-#define HASH_ADD_STR(head,strfield,add)                                          \
-    HASH_ADD(hh,head,strfield,strlen(add->strfield),add)
-#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
-  HASH_REPLACE(hh,head,strfield,strlen(add->strfield),add,replaced)
-#define HASH_FIND_INT(head,findint,out)                                          \
-    HASH_FIND(hh,head,findint,sizeof(int),out)
-#define HASH_ADD_INT(head,intfield,add)                                          \
-    HASH_ADD(hh,head,intfield,sizeof(int),add)
-#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
-#define HASH_FIND_PTR(head,findptr,out)                                          \
-    HASH_FIND(hh,head,findptr,sizeof(void *),out)
-#define HASH_ADD_PTR(head,ptrfield,add)                                          \
-    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
-#define HASH_REPLACE_PTR(head,ptrfield,add)                                      \
-    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
-#define HASH_DEL(head,delptr)                                                    \
-    HASH_DELETE(hh,head,delptr)
+#define HASH_FIND_STR(head, findstr, out)                                      \
+  HASH_FIND(hh, head, findstr, strlen(findstr), out)
+#define HASH_ADD_STR(head, strfield, add)                                      \
+  HASH_ADD(hh, head, strfield, strlen(add->strfield), add)
+#define HASH_REPLACE_STR(head, strfield, add, replaced)                        \
+  HASH_REPLACE(hh, head, strfield, strlen(add->strfield), add, replaced)
+#define HASH_FIND_INT(head, findint, out)                                      \
+  HASH_FIND(hh, head, findint, sizeof(int), out)
+#define HASH_ADD_INT(head, intfield, add)                                      \
+  HASH_ADD(hh, head, intfield, sizeof(int), add)
+#define HASH_REPLACE_INT(head, intfield, add, replaced)                        \
+  HASH_REPLACE(hh, head, intfield, sizeof(int), add, replaced)
+#define HASH_FIND_PTR(head, findptr, out)                                      \
+  HASH_FIND(hh, head, findptr, sizeof(void *), out)
+#define HASH_ADD_PTR(head, ptrfield, add)                                      \
+  HASH_ADD(hh, head, ptrfield, sizeof(void *), add)
+#define HASH_REPLACE_PTR(head, ptrfield, add)                                  \
+  HASH_REPLACE(hh, head, ptrfield, sizeof(void *), add, replaced)
+#define HASH_DEL(head, delptr) HASH_DELETE(hh, head, delptr)
 
-/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
- * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is
+ * defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't
+ * defined.
  */
 #ifdef HASH_DEBUG
-#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
-#define HASH_FSCK(hh,head)                                                       \
-do {                                                                             \
-    unsigned _bkt_i;                                                             \
-    unsigned _count, _bkt_count;                                                 \
-    char *_prev;                                                                 \
-    struct UT_hash_handle *_thh;                                                 \
-    if (head) {                                                                  \
-        _count = 0;                                                              \
-        for( _bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; _bkt_i++) {       \
-            _bkt_count = 0;                                                      \
-            _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                      \
-            _prev = NULL;                                                        \
-            while (_thh) {                                                       \
-               if (_prev != (char*)(_thh->hh_prev)) {                            \
-                   HASH_OOPS("invalid hh_prev %p, actual %p\n",                  \
-                    _thh->hh_prev, _prev );                                      \
-               }                                                                 \
-               _bkt_count++;                                                     \
-               _prev = (char*)(_thh);                                            \
-               _thh = _thh->hh_next;                                             \
-            }                                                                    \
-            _count += _bkt_count;                                                \
-            if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {          \
-               HASH_OOPS("invalid bucket count %d, actual %d\n",                 \
-                (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);              \
-            }                                                                    \
-        }                                                                        \
-        if (_count != (head)->hh.tbl->num_items) {                               \
-            HASH_OOPS("invalid hh item count %d, actual %d\n",                   \
-                (head)->hh.tbl->num_items, _count );                             \
-        }                                                                        \
-        /* traverse hh in app order; check next/prev integrity, count */         \
-        _count = 0;                                                              \
-        _prev = NULL;                                                            \
-        _thh =  &(head)->hh;                                                     \
-        while (_thh) {                                                           \
-           _count++;                                                             \
-           if (_prev !=(char*)(_thh->prev)) {                                    \
-              HASH_OOPS("invalid prev %p, actual %p\n",                          \
-                    _thh->prev, _prev );                                         \
-           }                                                                     \
-           _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                    \
-           _thh = ( _thh->next ?  (UT_hash_handle*)((char*)(_thh->next) +        \
-                                  (head)->hh.tbl->hho) : NULL );                 \
-        }                                                                        \
-        if (_count != (head)->hh.tbl->num_items) {                               \
-            HASH_OOPS("invalid app item count %d, actual %d\n",                  \
-                (head)->hh.tbl->num_items, _count );                             \
-        }                                                                        \
-    }                                                                            \
-} while (0)
+#define HASH_OOPS(...)                                                         \
+  do {                                                                         \
+    fprintf(stderr, __VA_ARGS__);                                              \
+    exit(-1);                                                                  \
+  } while (0)
+#define HASH_FSCK(hh, head)                                                    \
+  do {                                                                         \
+    unsigned _bkt_i;                                                           \
+    unsigned _count, _bkt_count;                                               \
+    char *_prev;                                                               \
+    struct UT_hash_handle *_thh;                                               \
+    if (head) {                                                                \
+      _count = 0;                                                              \
+      for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; _bkt_i++) {       \
+        _bkt_count = 0;                                                        \
+        _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                        \
+        _prev = NULL;                                                          \
+        while (_thh) {                                                         \
+          if (_prev != (char *)(_thh->hh_prev)) {                              \
+            HASH_OOPS("invalid hh_prev %p, actual %p\n", _thh->hh_prev,        \
+                      _prev);                                                  \
+          }                                                                    \
+          _bkt_count++;                                                        \
+          _prev = (char *)(_thh);                                              \
+          _thh = _thh->hh_next;                                                \
+        }                                                                      \
+        _count += _bkt_count;                                                  \
+        if ((head)->hh.tbl->buckets[_bkt_i].count != _bkt_count) {             \
+          HASH_OOPS("invalid bucket count %d, actual %d\n",                    \
+                    (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);        \
+        }                                                                      \
+      }                                                                        \
+      if (_count != (head)->hh.tbl->num_items) {                               \
+        HASH_OOPS("invalid hh item count %d, actual %d\n",                     \
+                  (head)->hh.tbl->num_items, _count);                          \
+      }                                                                        \
+      /* traverse hh in app order; check next/prev integrity, count */         \
+      _count = 0;                                                              \
+      _prev = NULL;                                                            \
+      _thh = &(head)->hh;                                                      \
+      while (_thh) {                                                           \
+        _count++;                                                              \
+        if (_prev != (char *)(_thh->prev)) {                                   \
+          HASH_OOPS("invalid prev %p, actual %p\n", _thh->prev, _prev);        \
+        }                                                                      \
+        _prev = (char *)ELMT_FROM_HH((head)->hh.tbl, _thh);                    \
+        _thh = (_thh->next ? (UT_hash_handle *)((char *)(_thh->next) +         \
+                                                (head)->hh.tbl->hho)           \
+                           : NULL);                                            \
+      }                                                                        \
+      if (_count != (head)->hh.tbl->num_items) {                               \
+        HASH_OOPS("invalid app item count %d, actual %d\n",                    \
+                  (head)->hh.tbl->num_items, _count);                          \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
 #else
-#define HASH_FSCK(hh,head)
+#define HASH_FSCK(hh, head)
 #endif
 
 /* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
  * the descriptor to which this macro is defined for tuning the hash function.
  * The app can #include <unistd.h> to get the prototype for write(2). */
 #ifdef HASH_EMIT_KEYS
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
-do {                                                                             \
-    unsigned _klen = fieldlen;                                                   \
-    write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                \
-    write(HASH_EMIT_KEYS, keyptr, fieldlen);                                     \
-} while (0)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)                              \
+  do {                                                                         \
+    unsigned _klen = fieldlen;                                                 \
+    write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                              \
+    write(HASH_EMIT_KEYS, keyptr, fieldlen);                                   \
+  } while (0)
 #else
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)
 #endif
 
 /* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
@@ -352,165 +366,198 @@ do {                                                                            
 #endif
 
 /* The Bernstein hash function, used in Perl prior to v5.6 */
-#define HASH_BER(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned _hb_keylen=keylen;                                                    \
-  char *_hb_key=(char*)(key);                                                    \
-  (hashv) = 0;                                                                   \
-  while (_hb_keylen--)  { (hashv) = ((hashv) * 33) + *_hb_key++; }               \
-  bkt = (hashv) & (num_bkts-1);                                                  \
-} while (0)
-
+#define HASH_BER(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned _hb_keylen = keylen;                                              \
+    char *_hb_key = (char *)(key);                                             \
+    (hashv) = 0;                                                               \
+    while (_hb_keylen--) {                                                     \
+      (hashv) = ((hashv)*33) + *_hb_key++;                                     \
+    }                                                                          \
+    bkt = (hashv) & (num_bkts - 1);                                            \
+  } while (0)
 
 /* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
  * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
-#define HASH_SAX(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned _sx_i;                                                                \
-  char *_hs_key=(char*)(key);                                                    \
-  hashv = 0;                                                                     \
-  for(_sx_i=0; _sx_i < keylen; _sx_i++)                                          \
-      hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                     \
-  bkt = hashv & (num_bkts-1);                                                    \
-} while (0)
+#define HASH_SAX(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned _sx_i;                                                            \
+    char *_hs_key = (char *)(key);                                             \
+    hashv = 0;                                                                 \
+    for (_sx_i = 0; _sx_i < keylen; _sx_i++)                                   \
+      hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                   \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
 
-#define HASH_FNV(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned _fn_i;                                                                \
-  char *_hf_key=(char*)(key);                                                    \
-  hashv = 2166136261UL;                                                          \
-  for(_fn_i=0; _fn_i < keylen; _fn_i++)                                          \
-      hashv = (hashv * 16777619) ^ _hf_key[_fn_i];                               \
-  bkt = hashv & (num_bkts-1);                                                    \
-} while(0)
+#define HASH_FNV(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned _fn_i;                                                            \
+    char *_hf_key = (char *)(key);                                             \
+    hashv = 2166136261UL;                                                      \
+    for (_fn_i = 0; _fn_i < keylen; _fn_i++)                                   \
+      hashv = (hashv * 16777619) ^ _hf_key[_fn_i];                             \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
 
-#define HASH_OAT(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned _ho_i;                                                                \
-  char *_ho_key=(char*)(key);                                                    \
-  hashv = 0;                                                                     \
-  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
-      hashv += _ho_key[_ho_i];                                                   \
-      hashv += (hashv << 10);                                                    \
-      hashv ^= (hashv >> 6);                                                     \
-  }                                                                              \
-  hashv += (hashv << 3);                                                         \
-  hashv ^= (hashv >> 11);                                                        \
-  hashv += (hashv << 15);                                                        \
-  bkt = hashv & (num_bkts-1);                                                    \
-} while(0)
+#define HASH_OAT(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned _ho_i;                                                            \
+    char *_ho_key = (char *)(key);                                             \
+    hashv = 0;                                                                 \
+    for (_ho_i = 0; _ho_i < keylen; _ho_i++) {                                 \
+      hashv += _ho_key[_ho_i];                                                 \
+      hashv += (hashv << 10);                                                  \
+      hashv ^= (hashv >> 6);                                                   \
+    }                                                                          \
+    hashv += (hashv << 3);                                                     \
+    hashv ^= (hashv >> 11);                                                    \
+    hashv += (hashv << 15);                                                    \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
 
-#define HASH_JEN_MIX(a,b,c)                                                      \
-do {                                                                             \
-  a -= b; a -= c; a ^= ( c >> 13 );                                              \
-  b -= c; b -= a; b ^= ( a << 8 );                                               \
-  c -= a; c -= b; c ^= ( b >> 13 );                                              \
-  a -= b; a -= c; a ^= ( c >> 12 );                                              \
-  b -= c; b -= a; b ^= ( a << 16 );                                              \
-  c -= a; c -= b; c ^= ( b >> 5 );                                               \
-  a -= b; a -= c; a ^= ( c >> 3 );                                               \
-  b -= c; b -= a; b ^= ( a << 10 );                                              \
-  c -= a; c -= b; c ^= ( b >> 15 );                                              \
-} while (0)
+#define HASH_JEN_MIX(a, b, c)                                                  \
+  do {                                                                         \
+    a -= b;                                                                    \
+    a -= c;                                                                    \
+    a ^= (c >> 13);                                                            \
+    b -= c;                                                                    \
+    b -= a;                                                                    \
+    b ^= (a << 8);                                                             \
+    c -= a;                                                                    \
+    c -= b;                                                                    \
+    c ^= (b >> 13);                                                            \
+    a -= b;                                                                    \
+    a -= c;                                                                    \
+    a ^= (c >> 12);                                                            \
+    b -= c;                                                                    \
+    b -= a;                                                                    \
+    b ^= (a << 16);                                                            \
+    c -= a;                                                                    \
+    c -= b;                                                                    \
+    c ^= (b >> 5);                                                             \
+    a -= b;                                                                    \
+    a -= c;                                                                    \
+    a ^= (c >> 3);                                                             \
+    b -= c;                                                                    \
+    b -= a;                                                                    \
+    b ^= (a << 10);                                                            \
+    c -= a;                                                                    \
+    c -= b;                                                                    \
+    c ^= (b >> 15);                                                            \
+  } while (0)
 
-#define HASH_JEN(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned _hj_i,_hj_j,_hj_k;                                                    \
-  unsigned char *_hj_key=(unsigned char*)(key);                                  \
-  hashv = 0xfeedbeef;                                                            \
-  _hj_i = _hj_j = 0x9e3779b9;                                                    \
-  _hj_k = (unsigned)keylen;                                                      \
-  while (_hj_k >= 12) {                                                          \
-    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
-        + ( (unsigned)_hj_key[2] << 16 )                                         \
-        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
-    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
-        + ( (unsigned)_hj_key[6] << 16 )                                         \
-        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
-    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
-        + ( (unsigned)_hj_key[10] << 16 )                                        \
-        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
-                                                                                 \
-     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
-                                                                                 \
-     _hj_key += 12;                                                              \
-     _hj_k -= 12;                                                                \
-  }                                                                              \
-  hashv += keylen;                                                               \
-  switch ( _hj_k ) {                                                             \
-     case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                          \
-     case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                           \
-     case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                            \
-     case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                           \
-     case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                           \
-     case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                            \
-     case 5:  _hj_j += _hj_key[4];                                               \
-     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                           \
-     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                           \
-     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                            \
-     case 1:  _hj_i += _hj_key[0];                                               \
-  }                                                                              \
-  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
-  bkt = hashv & (num_bkts-1);                                                    \
-} while(0)
+#define HASH_JEN(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned _hj_i, _hj_j, _hj_k;                                              \
+    unsigned char *_hj_key = (unsigned char *)(key);                           \
+    hashv = 0xfeedbeef;                                                        \
+    _hj_i = _hj_j = 0x9e3779b9;                                                \
+    _hj_k = (unsigned)keylen;                                                  \
+    while (_hj_k >= 12) {                                                      \
+      _hj_i += (_hj_key[0] + ((unsigned)_hj_key[1] << 8) +                     \
+                ((unsigned)_hj_key[2] << 16) + ((unsigned)_hj_key[3] << 24));  \
+      _hj_j += (_hj_key[4] + ((unsigned)_hj_key[5] << 8) +                     \
+                ((unsigned)_hj_key[6] << 16) + ((unsigned)_hj_key[7] << 24));  \
+      hashv +=                                                                 \
+          (_hj_key[8] + ((unsigned)_hj_key[9] << 8) +                          \
+           ((unsigned)_hj_key[10] << 16) + ((unsigned)_hj_key[11] << 24));     \
+                                                                               \
+      HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                       \
+                                                                               \
+      _hj_key += 12;                                                           \
+      _hj_k -= 12;                                                             \
+    }                                                                          \
+    hashv += keylen;                                                           \
+    switch (_hj_k) {                                                           \
+    case 11:                                                                   \
+      hashv += ((unsigned)_hj_key[10] << 24);                                  \
+    case 10:                                                                   \
+      hashv += ((unsigned)_hj_key[9] << 16);                                   \
+    case 9:                                                                    \
+      hashv += ((unsigned)_hj_key[8] << 8);                                    \
+    case 8:                                                                    \
+      _hj_j += ((unsigned)_hj_key[7] << 24);                                   \
+    case 7:                                                                    \
+      _hj_j += ((unsigned)_hj_key[6] << 16);                                   \
+    case 6:                                                                    \
+      _hj_j += ((unsigned)_hj_key[5] << 8);                                    \
+    case 5:                                                                    \
+      _hj_j += _hj_key[4];                                                     \
+    case 4:                                                                    \
+      _hj_i += ((unsigned)_hj_key[3] << 24);                                   \
+    case 3:                                                                    \
+      _hj_i += ((unsigned)_hj_key[2] << 16);                                   \
+    case 2:                                                                    \
+      _hj_i += ((unsigned)_hj_key[1] << 8);                                    \
+    case 1:                                                                    \
+      _hj_i += _hj_key[0];                                                     \
+    }                                                                          \
+    HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                         \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
 
 /* The Paul Hsieh hash function */
 #undef get16bits
-#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
-  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
-#define get16bits(d) (*((const uint16_t *) (d)))
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) ||        \
+    defined(_MSC_VER) || defined(__BORLANDC__) || defined(__TURBOC__)
+#define get16bits(d) (*((const uint16_t *)(d)))
 #endif
 
-#if !defined (get16bits)
-#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
-                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#if !defined(get16bits)
+#define get16bits(d)                                                           \
+  ((((uint32_t)(((const uint8_t *)(d))[1])) << 8) +                            \
+   (uint32_t)(((const uint8_t *)(d))[0]))
 #endif
-#define HASH_SFH(key,keylen,num_bkts,hashv,bkt)                                  \
-do {                                                                             \
-  unsigned char *_sfh_key=(unsigned char*)(key);                                 \
-  uint32_t _sfh_tmp, _sfh_len = keylen;                                          \
-                                                                                 \
-  int _sfh_rem = _sfh_len & 3;                                                   \
-  _sfh_len >>= 2;                                                                \
-  hashv = 0xcafebabe;                                                            \
-                                                                                 \
-  /* Main loop */                                                                \
-  for (;_sfh_len > 0; _sfh_len--) {                                              \
-    hashv    += get16bits (_sfh_key);                                            \
-    _sfh_tmp       = (uint32_t)(get16bits (_sfh_key+2)) << 11  ^ hashv;          \
-    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
-    _sfh_key += 2*sizeof (uint16_t);                                             \
-    hashv    += hashv >> 11;                                                     \
-  }                                                                              \
-                                                                                 \
-  /* Handle end cases */                                                         \
-  switch (_sfh_rem) {                                                            \
-    case 3: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 16;                                                \
-            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)] << 18);              \
-            hashv += hashv >> 11;                                                \
-            break;                                                               \
-    case 2: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 11;                                                \
-            hashv += hashv >> 17;                                                \
-            break;                                                               \
-    case 1: hashv += *_sfh_key;                                                  \
-            hashv ^= hashv << 10;                                                \
-            hashv += hashv >> 1;                                                 \
-  }                                                                              \
-                                                                                 \
-    /* Force "avalanching" of final 127 bits */                                  \
-    hashv ^= hashv << 3;                                                         \
-    hashv += hashv >> 5;                                                         \
-    hashv ^= hashv << 4;                                                         \
-    hashv += hashv >> 17;                                                        \
-    hashv ^= hashv << 25;                                                        \
-    hashv += hashv >> 6;                                                         \
-    bkt = hashv & (num_bkts-1);                                                  \
-} while(0)
+#define HASH_SFH(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    unsigned char *_sfh_key = (unsigned char *)(key);                          \
+    uint32_t _sfh_tmp, _sfh_len = keylen;                                      \
+                                                                               \
+    int _sfh_rem = _sfh_len & 3;                                               \
+    _sfh_len >>= 2;                                                            \
+    hashv = 0xcafebabe;                                                        \
+                                                                               \
+    /* Main loop */                                                            \
+    for (; _sfh_len > 0; _sfh_len--) {                                         \
+      hashv += get16bits(_sfh_key);                                            \
+      _sfh_tmp = (uint32_t)(get16bits(_sfh_key + 2)) << 11 ^ hashv;            \
+      hashv = (hashv << 16) ^ _sfh_tmp;                                        \
+      _sfh_key += 2 * sizeof(uint16_t);                                        \
+      hashv += hashv >> 11;                                                    \
+    }                                                                          \
+                                                                               \
+    /* Handle end cases */                                                     \
+    switch (_sfh_rem) {                                                        \
+    case 3:                                                                    \
+      hashv += get16bits(_sfh_key);                                            \
+      hashv ^= hashv << 16;                                                    \
+      hashv ^= (uint32_t)(_sfh_key[sizeof(uint16_t)] << 18);                   \
+      hashv += hashv >> 11;                                                    \
+      break;                                                                   \
+    case 2:                                                                    \
+      hashv += get16bits(_sfh_key);                                            \
+      hashv ^= hashv << 11;                                                    \
+      hashv += hashv >> 17;                                                    \
+      break;                                                                   \
+    case 1:                                                                    \
+      hashv += *_sfh_key;                                                      \
+      hashv ^= hashv << 10;                                                    \
+      hashv += hashv >> 1;                                                     \
+    }                                                                          \
+                                                                               \
+    /* Force "avalanching" of final 127 bits */                                \
+    hashv ^= hashv << 3;                                                       \
+    hashv += hashv >> 5;                                                       \
+    hashv ^= hashv << 4;                                                       \
+    hashv += hashv >> 17;                                                      \
+    hashv ^= hashv << 25;                                                      \
+    hashv += hashv >> 6;                                                       \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
 
 #ifdef HASH_USING_NO_STRICT_ALIASING
-/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
+/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned
+ * reads.
  * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
  * MurmurHash uses the faster approach only on CPU's where we know it's safe.
  *
@@ -519,120 +566,140 @@ do {                                                                            
  *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
  *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
  */
-#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
-#define MUR_GETBLOCK(p,i) p[i]
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86))
+#define MUR_GETBLOCK(p, i) p[i]
 #else /* non intel */
 #define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 0x3) == 0)
 #define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 0x3) == 1)
 #define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 0x3) == 2)
 #define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 0x3) == 3)
-#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
-#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
-#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#define WP(p) ((uint32_t *)((unsigned long)(p) & ~3UL))
+#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) ||          \
+     defined(__ppc64__))
+#define MUR_THREE_ONE(p)                                                       \
+  ((((*WP(p)) & 0x00ffffff) << 8) | (((*(WP(p) + 1)) & 0xff000000) >> 24))
+#define MUR_TWO_TWO(p)                                                         \
+  ((((*WP(p)) & 0x0000ffff) << 16) | (((*(WP(p) + 1)) & 0xffff0000) >> 16))
+#define MUR_ONE_THREE(p)                                                       \
+  ((((*WP(p)) & 0x000000ff) << 24) | (((*(WP(p) + 1)) & 0xffffff00) >> 8))
 #else /* assume little endian non-intel */
-#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#define MUR_THREE_ONE(p)                                                       \
+  ((((*WP(p)) & 0xffffff00) >> 8) | (((*(WP(p) + 1)) & 0x000000ff) << 24))
+#define MUR_TWO_TWO(p)                                                         \
+  ((((*WP(p)) & 0xffff0000) >> 16) | (((*(WP(p) + 1)) & 0x0000ffff) << 16))
+#define MUR_ONE_THREE(p)                                                       \
+  ((((*WP(p)) & 0xff000000) >> 24) | (((*(WP(p) + 1)) & 0x00ffffff) << 8))
 #endif
-#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
-                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
-                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
-                                                      MUR_ONE_THREE(p))))
+#define MUR_GETBLOCK(p, i)                                                     \
+  (MUR_PLUS0_ALIGNED(p)                                                        \
+       ? ((p)[i])                                                              \
+       : (MUR_PLUS1_ALIGNED(p)                                                 \
+              ? MUR_THREE_ONE(p)                                               \
+              : (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) : MUR_ONE_THREE(p))))
 #endif
-#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
-#define MUR_FMIX(_h) \
-do {                 \
-  _h ^= _h >> 16;    \
-  _h *= 0x85ebca6b;  \
-  _h ^= _h >> 13;    \
-  _h *= 0xc2b2ae35l; \
-  _h ^= _h >> 16;    \
-} while(0)
+#define MUR_ROTL32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h)                                                           \
+  do {                                                                         \
+    _h ^= _h >> 16;                                                            \
+    _h *= 0x85ebca6b;                                                          \
+    _h ^= _h >> 13;                                                            \
+    _h *= 0xc2b2ae35l;                                                         \
+    _h ^= _h >> 16;                                                            \
+  } while (0)
 
-#define HASH_MUR(key,keylen,num_bkts,hashv,bkt)                        \
-do {                                                                   \
-  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
-  const int _mur_nblocks = (keylen) / 4;                               \
-  uint32_t _mur_h1 = 0xf88D5353;                                       \
-  uint32_t _mur_c1 = 0xcc9e2d51;                                       \
-  uint32_t _mur_c2 = 0x1b873593;                                       \
-  uint32_t _mur_k1 = 0;                                                \
-  const uint8_t *_mur_tail;                                            \
-  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+_mur_nblocks*4); \
-  int _mur_i;                                                          \
-  for(_mur_i = -_mur_nblocks; _mur_i; _mur_i++) {                      \
-    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-                                                                       \
-    _mur_h1 ^= _mur_k1;                                                \
-    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
-    _mur_h1 = _mur_h1*5+0xe6546b64;                                    \
-  }                                                                    \
-  _mur_tail = (const uint8_t*)(_mur_data + _mur_nblocks*4);            \
-  _mur_k1=0;                                                           \
-  switch((keylen) & 3) {                                               \
-    case 3: _mur_k1 ^= _mur_tail[2] << 16;                             \
-    case 2: _mur_k1 ^= _mur_tail[1] << 8;                              \
-    case 1: _mur_k1 ^= _mur_tail[0];                                   \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-    _mur_h1 ^= _mur_k1;                                                \
-  }                                                                    \
-  _mur_h1 ^= (keylen);                                                 \
-  MUR_FMIX(_mur_h1);                                                   \
-  hashv = _mur_h1;                                                     \
-  bkt = hashv & (num_bkts-1);                                          \
-} while(0)
-#endif  /* HASH_USING_NO_STRICT_ALIASING */
+#define HASH_MUR(key, keylen, num_bkts, hashv, bkt)                            \
+  do {                                                                         \
+    const uint8_t *_mur_data = (const uint8_t *)(key);                         \
+    const int _mur_nblocks = (keylen) / 4;                                     \
+    uint32_t _mur_h1 = 0xf88D5353;                                             \
+    uint32_t _mur_c1 = 0xcc9e2d51;                                             \
+    uint32_t _mur_c2 = 0x1b873593;                                             \
+    uint32_t _mur_k1 = 0;                                                      \
+    const uint8_t *_mur_tail;                                                  \
+    const uint32_t *_mur_blocks =                                              \
+        (const uint32_t *)(_mur_data + _mur_nblocks * 4);                      \
+    int _mur_i;                                                                \
+    for (_mur_i = -_mur_nblocks; _mur_i; _mur_i++) {                           \
+      _mur_k1 = MUR_GETBLOCK(_mur_blocks, _mur_i);                             \
+      _mur_k1 *= _mur_c1;                                                      \
+      _mur_k1 = MUR_ROTL32(_mur_k1, 15);                                       \
+      _mur_k1 *= _mur_c2;                                                      \
+                                                                               \
+      _mur_h1 ^= _mur_k1;                                                      \
+      _mur_h1 = MUR_ROTL32(_mur_h1, 13);                                       \
+      _mur_h1 = _mur_h1 * 5 + 0xe6546b64;                                      \
+    }                                                                          \
+    _mur_tail = (const uint8_t *)(_mur_data + _mur_nblocks * 4);               \
+    _mur_k1 = 0;                                                               \
+    switch ((keylen)&3) {                                                      \
+    case 3:                                                                    \
+      _mur_k1 ^= _mur_tail[2] << 16;                                           \
+    case 2:                                                                    \
+      _mur_k1 ^= _mur_tail[1] << 8;                                            \
+    case 1:                                                                    \
+      _mur_k1 ^= _mur_tail[0];                                                 \
+      _mur_k1 *= _mur_c1;                                                      \
+      _mur_k1 = MUR_ROTL32(_mur_k1, 15);                                       \
+      _mur_k1 *= _mur_c2;                                                      \
+      _mur_h1 ^= _mur_k1;                                                      \
+    }                                                                          \
+    _mur_h1 ^= (keylen);                                                       \
+    MUR_FMIX(_mur_h1);                                                         \
+    hashv = _mur_h1;                                                           \
+    bkt = hashv & (num_bkts - 1);                                              \
+  } while (0)
+#endif /* HASH_USING_NO_STRICT_ALIASING */
 
 /* key comparison function; return 0 if keys equal */
-#define HASH_KEYCMP(a,b,len) memcmp(a,b,len)
+#define HASH_KEYCMP(a, b, len) memcmp(a, b, len)
 
 /* iterate over items in a known bucket to find desired item */
-#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,out)                       \
-do {                                                                             \
- if (head.hh_head) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,head.hh_head));          \
- else out=NULL;                                                                  \
- while (out) {                                                                   \
-    if ((out)->hh.keylen == keylen_in) {                                           \
-        if ((HASH_KEYCMP((out)->hh.key,keyptr,keylen_in)) == 0) break;             \
-    }                                                                            \
-    if ((out)->hh.hh_next) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,(out)->hh.hh_next)); \
-    else out = NULL;                                                             \
- }                                                                               \
-} while(0)
+#define HASH_FIND_IN_BKT(tbl, hh, head, keyptr, keylen_in, out)                \
+  do {                                                                         \
+    if (head.hh_head)                                                          \
+      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, head.hh_head));                   \
+    else                                                                       \
+      out = NULL;                                                              \
+    while (out) {                                                              \
+      if ((out)->hh.keylen == keylen_in) {                                     \
+        if ((HASH_KEYCMP((out)->hh.key, keyptr, keylen_in)) == 0)              \
+          break;                                                               \
+      }                                                                        \
+      if ((out)->hh.hh_next)                                                   \
+        DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));            \
+      else                                                                     \
+        out = NULL;                                                            \
+    }                                                                          \
+  } while (0)
 
 /* add an item to a bucket  */
-#define HASH_ADD_TO_BKT(head,addhh)                                              \
-do {                                                                             \
- head.count++;                                                                   \
- (addhh)->hh_next = head.hh_head;                                                \
- (addhh)->hh_prev = NULL;                                                        \
- if (head.hh_head) { (head).hh_head->hh_prev = (addhh); }                        \
- (head).hh_head=addhh;                                                           \
- if (head.count >= ((head.expand_mult+1) * HASH_BKT_CAPACITY_THRESH)             \
-     && (addhh)->tbl->noexpand != 1) {                                           \
-       HASH_EXPAND_BUCKETS((addhh)->tbl);                                        \
- }                                                                               \
-} while(0)
+#define HASH_ADD_TO_BKT(head, addhh)                                           \
+  do {                                                                         \
+    head.count++;                                                              \
+    (addhh)->hh_next = head.hh_head;                                           \
+    (addhh)->hh_prev = NULL;                                                   \
+    if (head.hh_head) {                                                        \
+      (head).hh_head->hh_prev = (addhh);                                       \
+    }                                                                          \
+    (head).hh_head = addhh;                                                    \
+    if (head.count >= ((head.expand_mult + 1) * HASH_BKT_CAPACITY_THRESH) &&   \
+        (addhh)->tbl->noexpand != 1) {                                         \
+      HASH_EXPAND_BUCKETS((addhh)->tbl);                                       \
+    }                                                                          \
+  } while (0)
 
 /* remove an item from a given bucket */
-#define HASH_DEL_IN_BKT(hh,head,hh_del)                                          \
-    (head).count--;                                                              \
-    if ((head).hh_head == hh_del) {                                              \
-      (head).hh_head = hh_del->hh_next;                                          \
-    }                                                                            \
-    if (hh_del->hh_prev) {                                                       \
-        hh_del->hh_prev->hh_next = hh_del->hh_next;                              \
-    }                                                                            \
-    if (hh_del->hh_next) {                                                       \
-        hh_del->hh_next->hh_prev = hh_del->hh_prev;                              \
-    }
+#define HASH_DEL_IN_BKT(hh, head, hh_del)                                      \
+  (head).count--;                                                              \
+  if ((head).hh_head == hh_del) {                                              \
+    (head).hh_head = hh_del->hh_next;                                          \
+  }                                                                            \
+  if (hh_del->hh_prev) {                                                       \
+    hh_del->hh_prev->hh_next = hh_del->hh_next;                                \
+  }                                                                            \
+  if (hh_del->hh_next) {                                                       \
+    hh_del->hh_next->hh_prev = hh_del->hh_prev;                                \
+  }
 
 /* Bucket expansion has the effect of doubling the number of buckets
  * and redistributing the items into the new buckets. Ideally the
@@ -663,229 +730,244 @@ do {                                                                            
  *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
  *
  */
-#define HASH_EXPAND_BUCKETS(tbl)                                                 \
-do {                                                                             \
-    unsigned _he_bkt;                                                            \
-    unsigned _he_bkt_i;                                                          \
-    struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                 \
-    UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                \
-    _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                            \
-             2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));              \
-    if (!_he_new_buckets) { uthash_fatal( "out of memory"); }                    \
-    memset(_he_new_buckets, 0,                                                   \
-            2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));               \
-    tbl->ideal_chain_maxlen =                                                    \
-       (tbl->num_items >> (tbl->log2_num_buckets+1)) +                           \
-       ((tbl->num_items & ((tbl->num_buckets*2)-1)) ? 1 : 0);                    \
-    tbl->nonideal_items = 0;                                                     \
-    for(_he_bkt_i = 0; _he_bkt_i < tbl->num_buckets; _he_bkt_i++)                \
-    {                                                                            \
-        _he_thh = tbl->buckets[ _he_bkt_i ].hh_head;                             \
-        while (_he_thh) {                                                        \
-           _he_hh_nxt = _he_thh->hh_next;                                        \
-           HASH_TO_BKT( _he_thh->hashv, tbl->num_buckets*2, _he_bkt);            \
-           _he_newbkt = &(_he_new_buckets[ _he_bkt ]);                           \
-           if (++(_he_newbkt->count) > tbl->ideal_chain_maxlen) {                \
-             tbl->nonideal_items++;                                              \
-             _he_newbkt->expand_mult = _he_newbkt->count /                       \
-                                        tbl->ideal_chain_maxlen;                 \
-           }                                                                     \
-           _he_thh->hh_prev = NULL;                                              \
-           _he_thh->hh_next = _he_newbkt->hh_head;                               \
-           if (_he_newbkt->hh_head) _he_newbkt->hh_head->hh_prev =               \
-                _he_thh;                                                         \
-           _he_newbkt->hh_head = _he_thh;                                        \
-           _he_thh = _he_hh_nxt;                                                 \
-        }                                                                        \
-    }                                                                            \
-    uthash_free( tbl->buckets, tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
-    tbl->num_buckets *= 2;                                                       \
-    tbl->log2_num_buckets++;                                                     \
-    tbl->buckets = _he_new_buckets;                                              \
-    tbl->ineff_expands = (tbl->nonideal_items > (tbl->num_items >> 1)) ?         \
-        (tbl->ineff_expands+1) : 0;                                              \
-    if (tbl->ineff_expands > 1) {                                                \
-        tbl->noexpand=1;                                                         \
-        uthash_noexpand_fyi(tbl);                                                \
-    }                                                                            \
-    uthash_expand_fyi(tbl);                                                      \
-} while(0)
-
+#define HASH_EXPAND_BUCKETS(tbl)                                               \
+  do {                                                                         \
+    unsigned _he_bkt;                                                          \
+    unsigned _he_bkt_i;                                                        \
+    struct UT_hash_handle *_he_thh, *_he_hh_nxt;                               \
+    UT_hash_bucket *_he_new_buckets, *_he_newbkt;                              \
+    _he_new_buckets = (UT_hash_bucket *)uthash_malloc(                         \
+        2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));                 \
+    if (!_he_new_buckets) {                                                    \
+      uthash_fatal("out of memory");                                           \
+    }                                                                          \
+    memset(_he_new_buckets, 0,                                                 \
+           2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));              \
+    tbl->ideal_chain_maxlen =                                                  \
+        (tbl->num_items >> (tbl->log2_num_buckets + 1)) +                      \
+        ((tbl->num_items & ((tbl->num_buckets * 2) - 1)) ? 1 : 0);             \
+    tbl->nonideal_items = 0;                                                   \
+    for (_he_bkt_i = 0; _he_bkt_i < tbl->num_buckets; _he_bkt_i++) {           \
+      _he_thh = tbl->buckets[_he_bkt_i].hh_head;                               \
+      while (_he_thh) {                                                        \
+        _he_hh_nxt = _he_thh->hh_next;                                         \
+        HASH_TO_BKT(_he_thh->hashv, tbl->num_buckets * 2, _he_bkt);            \
+        _he_newbkt = &(_he_new_buckets[_he_bkt]);                              \
+        if (++(_he_newbkt->count) > tbl->ideal_chain_maxlen) {                 \
+          tbl->nonideal_items++;                                               \
+          _he_newbkt->expand_mult =                                            \
+              _he_newbkt->count / tbl->ideal_chain_maxlen;                     \
+        }                                                                      \
+        _he_thh->hh_prev = NULL;                                               \
+        _he_thh->hh_next = _he_newbkt->hh_head;                                \
+        if (_he_newbkt->hh_head)                                               \
+          _he_newbkt->hh_head->hh_prev = _he_thh;                              \
+        _he_newbkt->hh_head = _he_thh;                                         \
+        _he_thh = _he_hh_nxt;                                                  \
+      }                                                                        \
+    }                                                                          \
+    uthash_free(tbl->buckets,                                                  \
+                tbl->num_buckets * sizeof(struct UT_hash_bucket));             \
+    tbl->num_buckets *= 2;                                                     \
+    tbl->log2_num_buckets++;                                                   \
+    tbl->buckets = _he_new_buckets;                                            \
+    tbl->ineff_expands = (tbl->nonideal_items > (tbl->num_items >> 1))         \
+                             ? (tbl->ineff_expands + 1)                        \
+                             : 0;                                              \
+    if (tbl->ineff_expands > 1) {                                              \
+      tbl->noexpand = 1;                                                       \
+      uthash_noexpand_fyi(tbl);                                                \
+    }                                                                          \
+    uthash_expand_fyi(tbl);                                                    \
+  } while (0)
 
 /* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
 /* Note that HASH_SORT assumes the hash handle name to be hh.
  * HASH_SRT was added to allow the hash handle name to be passed in. */
-#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
-#define HASH_SRT(hh,head,cmpfcn)                                                 \
-do {                                                                             \
-  unsigned _hs_i;                                                                \
-  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
-  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
-  if (head) {                                                                    \
-      _hs_insize = 1;                                                            \
-      _hs_looping = 1;                                                           \
-      _hs_list = &((head)->hh);                                                  \
-      while (_hs_looping) {                                                      \
-          _hs_p = _hs_list;                                                      \
-          _hs_list = NULL;                                                       \
-          _hs_tail = NULL;                                                       \
-          _hs_nmerges = 0;                                                       \
-          while (_hs_p) {                                                        \
-              _hs_nmerges++;                                                     \
-              _hs_q = _hs_p;                                                     \
-              _hs_psize = 0;                                                     \
-              for ( _hs_i = 0; _hs_i  < _hs_insize; _hs_i++ ) {                  \
-                  _hs_psize++;                                                   \
-                  _hs_q = (UT_hash_handle*)((_hs_q->next) ?                      \
-                          ((void*)((char*)(_hs_q->next) +                        \
-                          (head)->hh.tbl->hho)) : NULL);                         \
-                  if (! (_hs_q) ) break;                                         \
-              }                                                                  \
-              _hs_qsize = _hs_insize;                                            \
-              while ((_hs_psize > 0) || ((_hs_qsize > 0) && _hs_q )) {           \
-                  if (_hs_psize == 0) {                                          \
-                      _hs_e = _hs_q;                                             \
-                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
-                              ((void*)((char*)(_hs_q->next) +                    \
-                              (head)->hh.tbl->hho)) : NULL);                     \
-                      _hs_qsize--;                                               \
-                  } else if ( (_hs_qsize == 0) || !(_hs_q) ) {                   \
-                      _hs_e = _hs_p;                                             \
-                      _hs_p = (UT_hash_handle*)((_hs_p->next) ?                  \
-                              ((void*)((char*)(_hs_p->next) +                    \
-                              (head)->hh.tbl->hho)) : NULL);                     \
-                      _hs_psize--;                                               \
-                  } else if ((                                                   \
-                      cmpfcn(DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_p)), \
-                             DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_q))) \
-                             ) <= 0) {                                           \
-                      _hs_e = _hs_p;                                             \
-                      _hs_p = (UT_hash_handle*)((_hs_p->next) ?                  \
-                              ((void*)((char*)(_hs_p->next) +                    \
-                              (head)->hh.tbl->hho)) : NULL);                     \
-                      _hs_psize--;                                               \
-                  } else {                                                       \
-                      _hs_e = _hs_q;                                             \
-                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
-                              ((void*)((char*)(_hs_q->next) +                    \
-                              (head)->hh.tbl->hho)) : NULL);                     \
-                      _hs_qsize--;                                               \
-                  }                                                              \
-                  if ( _hs_tail ) {                                              \
-                      _hs_tail->next = ((_hs_e) ?                                \
-                            ELMT_FROM_HH((head)->hh.tbl,_hs_e) : NULL);          \
-                  } else {                                                       \
-                      _hs_list = _hs_e;                                          \
-                  }                                                              \
-                  _hs_e->prev = ((_hs_tail) ?                                    \
-                     ELMT_FROM_HH((head)->hh.tbl,_hs_tail) : NULL);              \
-                  _hs_tail = _hs_e;                                              \
-              }                                                                  \
-              _hs_p = _hs_q;                                                     \
-          }                                                                      \
-          _hs_tail->next = NULL;                                                 \
-          if ( _hs_nmerges <= 1 ) {                                              \
-              _hs_looping=0;                                                     \
-              (head)->hh.tbl->tail = _hs_tail;                                   \
-              DECLTYPE_ASSIGN(head,ELMT_FROM_HH((head)->hh.tbl, _hs_list));      \
-          }                                                                      \
-          _hs_insize *= 2;                                                       \
-      }                                                                          \
-      HASH_FSCK(hh,head);                                                        \
- }                                                                               \
-} while (0)
+#define HASH_SORT(head, cmpfcn) HASH_SRT(hh, head, cmpfcn)
+#define HASH_SRT(hh, head, cmpfcn)                                             \
+  do {                                                                         \
+    unsigned _hs_i;                                                            \
+    unsigned _hs_looping, _hs_nmerges, _hs_insize, _hs_psize, _hs_qsize;       \
+    struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;        \
+    if (head) {                                                                \
+      _hs_insize = 1;                                                          \
+      _hs_looping = 1;                                                         \
+      _hs_list = &((head)->hh);                                                \
+      while (_hs_looping) {                                                    \
+        _hs_p = _hs_list;                                                      \
+        _hs_list = NULL;                                                       \
+        _hs_tail = NULL;                                                       \
+        _hs_nmerges = 0;                                                       \
+        while (_hs_p) {                                                        \
+          _hs_nmerges++;                                                       \
+          _hs_q = _hs_p;                                                       \
+          _hs_psize = 0;                                                       \
+          for (_hs_i = 0; _hs_i < _hs_insize; _hs_i++) {                       \
+            _hs_psize++;                                                       \
+            _hs_q = (UT_hash_handle *)((_hs_q->next)                           \
+                                           ? ((void *)((char *)(_hs_q->next) + \
+                                                       (head)->hh.tbl->hho))   \
+                                           : NULL);                            \
+            if (!(_hs_q))                                                      \
+              break;                                                           \
+          }                                                                    \
+          _hs_qsize = _hs_insize;                                              \
+          while ((_hs_psize > 0) || ((_hs_qsize > 0) && _hs_q)) {              \
+            if (_hs_psize == 0) {                                              \
+              _hs_e = _hs_q;                                                   \
+              _hs_q =                                                          \
+                  (UT_hash_handle *)((_hs_q->next)                             \
+                                         ? ((void *)((char *)(_hs_q->next) +   \
+                                                     (head)->hh.tbl->hho))     \
+                                         : NULL);                              \
+              _hs_qsize--;                                                     \
+            } else if ((_hs_qsize == 0) || !(_hs_q)) {                         \
+              _hs_e = _hs_p;                                                   \
+              _hs_p =                                                          \
+                  (UT_hash_handle *)((_hs_p->next)                             \
+                                         ? ((void *)((char *)(_hs_p->next) +   \
+                                                     (head)->hh.tbl->hho))     \
+                                         : NULL);                              \
+              _hs_psize--;                                                     \
+            } else if ((cmpfcn(DECLTYPE(head)(                                 \
+                                   ELMT_FROM_HH((head)->hh.tbl, _hs_p)),       \
+                               DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,     \
+                                                           _hs_q)))) <= 0) {   \
+              _hs_e = _hs_p;                                                   \
+              _hs_p =                                                          \
+                  (UT_hash_handle *)((_hs_p->next)                             \
+                                         ? ((void *)((char *)(_hs_p->next) +   \
+                                                     (head)->hh.tbl->hho))     \
+                                         : NULL);                              \
+              _hs_psize--;                                                     \
+            } else {                                                           \
+              _hs_e = _hs_q;                                                   \
+              _hs_q =                                                          \
+                  (UT_hash_handle *)((_hs_q->next)                             \
+                                         ? ((void *)((char *)(_hs_q->next) +   \
+                                                     (head)->hh.tbl->hho))     \
+                                         : NULL);                              \
+              _hs_qsize--;                                                     \
+            }                                                                  \
+            if (_hs_tail) {                                                    \
+              _hs_tail->next =                                                 \
+                  ((_hs_e) ? ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);      \
+            } else {                                                           \
+              _hs_list = _hs_e;                                                \
+            }                                                                  \
+            _hs_e->prev =                                                      \
+                ((_hs_tail) ? ELMT_FROM_HH((head)->hh.tbl, _hs_tail) : NULL);  \
+            _hs_tail = _hs_e;                                                  \
+          }                                                                    \
+          _hs_p = _hs_q;                                                       \
+        }                                                                      \
+        _hs_tail->next = NULL;                                                 \
+        if (_hs_nmerges <= 1) {                                                \
+          _hs_looping = 0;                                                     \
+          (head)->hh.tbl->tail = _hs_tail;                                     \
+          DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));       \
+        }                                                                      \
+        _hs_insize *= 2;                                                       \
+      }                                                                        \
+      HASH_FSCK(hh, head);                                                     \
+    }                                                                          \
+  } while (0)
 
 /* This function selects items from one hash into another hash.
  * The end result is that the selected items have dual presence
  * in both hashes. There is no copy of the items made; rather
  * they are added into the new hash through a secondary hash
  * hash handle that must be present in the structure. */
-#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
-do {                                                                             \
-  unsigned _src_bkt, _dst_bkt;                                                   \
-  void *_last_elt=NULL, *_elt;                                                   \
-  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
-  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
-  if (src) {                                                                     \
-    for(_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {     \
-      for(_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;                \
-          _src_hh;                                                               \
-          _src_hh = _src_hh->hh_next) {                                          \
-          _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                       \
-          if (cond(_elt)) {                                                      \
-            _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);               \
-            _dst_hh->key = _src_hh->key;                                         \
-            _dst_hh->keylen = _src_hh->keylen;                                   \
-            _dst_hh->hashv = _src_hh->hashv;                                     \
-            _dst_hh->prev = _last_elt;                                           \
-            _dst_hh->next = NULL;                                                \
-            if (_last_elt_hh) { _last_elt_hh->next = _elt; }                     \
-            if (!dst) {                                                          \
-              DECLTYPE_ASSIGN(dst,_elt);                                         \
-              HASH_MAKE_TABLE(hh_dst,dst);                                       \
-            } else {                                                             \
-              _dst_hh->tbl = (dst)->hh_dst.tbl;                                  \
-            }                                                                    \
-            HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);    \
-            HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt],_dst_hh);            \
-            (dst)->hh_dst.tbl->num_items++;                                      \
-            _last_elt = _elt;                                                    \
-            _last_elt_hh = _dst_hh;                                              \
-          }                                                                      \
-      }                                                                          \
-    }                                                                            \
-  }                                                                              \
-  HASH_FSCK(hh_dst,dst);                                                         \
-} while (0)
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                            \
+  do {                                                                         \
+    unsigned _src_bkt, _dst_bkt;                                               \
+    void *_last_elt = NULL, *_elt;                                             \
+    UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh = NULL;                   \
+    ptrdiff_t _dst_hho = ((char *)(&(dst)->hh_dst) - (char *)(dst));           \
+    if (src) {                                                                 \
+      for (_src_bkt = 0; _src_bkt < (src)->hh_src.tbl->num_buckets;            \
+           _src_bkt++) {                                                       \
+        for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head; _src_hh;  \
+             _src_hh = _src_hh->hh_next) {                                     \
+          _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                     \
+          if (cond(_elt)) {                                                    \
+            _dst_hh = (UT_hash_handle *)(((char *)_elt) + _dst_hho);           \
+            _dst_hh->key = _src_hh->key;                                       \
+            _dst_hh->keylen = _src_hh->keylen;                                 \
+            _dst_hh->hashv = _src_hh->hashv;                                   \
+            _dst_hh->prev = _last_elt;                                         \
+            _dst_hh->next = NULL;                                              \
+            if (_last_elt_hh) {                                                \
+              _last_elt_hh->next = _elt;                                       \
+            }                                                                  \
+            if (!dst) {                                                        \
+              DECLTYPE_ASSIGN(dst, _elt);                                      \
+              HASH_MAKE_TABLE(hh_dst, dst);                                    \
+            } else {                                                           \
+              _dst_hh->tbl = (dst)->hh_dst.tbl;                                \
+            }                                                                  \
+            HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);  \
+            HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt], _dst_hh);         \
+            (dst)->hh_dst.tbl->num_items++;                                    \
+            _last_elt = _elt;                                                  \
+            _last_elt_hh = _dst_hh;                                            \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+    HASH_FSCK(hh_dst, dst);                                                    \
+  } while (0)
 
-#define HASH_CLEAR(hh,head)                                                      \
-do {                                                                             \
-  if (head) {                                                                    \
-    uthash_free((head)->hh.tbl->buckets,                                         \
-                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
-    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
-    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
-    (head)=NULL;                                                                 \
-  }                                                                              \
-} while(0)
+#define HASH_CLEAR(hh, head)                                                   \
+  do {                                                                         \
+    if (head) {                                                                \
+      uthash_free((head)->hh.tbl->buckets, (head)->hh.tbl->num_buckets *       \
+                                               sizeof(struct UT_hash_bucket)); \
+      HASH_BLOOM_FREE((head)->hh.tbl);                                         \
+      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
+      (head) = NULL;                                                           \
+    }                                                                          \
+  } while (0)
 
-#define HASH_OVERHEAD(hh,head)                                                   \
- (size_t)((((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +            \
-           ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +            \
-            (sizeof(UT_hash_table))                                 +            \
-            (HASH_BLOOM_BYTELEN)))
+#define HASH_OVERHEAD(hh, head)                                                \
+  (size_t)((((head)->hh.tbl->num_items * sizeof(UT_hash_handle)) +             \
+            ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket)) +           \
+            (sizeof(UT_hash_table)) + (HASH_BLOOM_BYTELEN)))
 
 #ifdef NO_DECLTYPE
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for((el)=(head), (*(char**)(&(tmp)))=(char*)((head)?(head)->hh.next:NULL);       \
-  el; (el)=(tmp),(*(char**)(&(tmp)))=(char*)((tmp)?(tmp)->hh.next:NULL))
+#define HASH_ITER(hh, head, el, tmp)                                           \
+  for ((el) = (head),                                                          \
+      (*(char **)(&(tmp))) = (char *)((head) ? (head)->hh.next : NULL);        \
+       el; (el) = (tmp),                                                       \
+      (*(char **)(&(tmp))) = (char *)((tmp) ? (tmp)->hh.next : NULL))
 #else
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for((el)=(head),(tmp)=DECLTYPE(el)((head)?(head)->hh.next:NULL);                 \
-  el; (el)=(tmp),(tmp)=DECLTYPE(el)((tmp)?(tmp)->hh.next:NULL))
+#define HASH_ITER(hh, head, el, tmp)                                           \
+  for ((el) = (head), (tmp) = DECLTYPE(el)((head) ? (head)->hh.next : NULL);   \
+       el; (el) = (tmp), (tmp) = DECLTYPE(el)((tmp) ? (tmp)->hh.next : NULL))
 #endif
 
 /* obtain a count of items in the hash */
-#define HASH_COUNT(head) HASH_CNT(hh,head)
-#define HASH_CNT(hh,head) ((head)?((head)->hh.tbl->num_items):0)
+#define HASH_COUNT(head) HASH_CNT(hh, head)
+#define HASH_CNT(hh, head) ((head) ? ((head)->hh.tbl->num_items) : 0)
 
 typedef struct UT_hash_bucket {
-   struct UT_hash_handle *hh_head;
-   unsigned count;
+  struct UT_hash_handle *hh_head;
+  unsigned count;
 
-   /* expand_mult is normally set to 0. In this situation, the max chain length
-    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
-    * the bucket's chain exceeds this length, bucket expansion is triggered).
-    * However, setting expand_mult to a non-zero value delays bucket expansion
-    * (that would be triggered by additions to this particular bucket)
-    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
-    * (The multiplier is simply expand_mult+1). The whole idea of this
-    * multiplier is to reduce bucket expansions, since they are expensive, in
-    * situations where we know that a particular bucket tends to be overused.
-    * It is better to let its chain length grow to a longer yet-still-bounded
-    * value, than to do an O(n) bucket expansion too often.
-    */
-   unsigned expand_mult;
+  /* expand_mult is normally set to 0. In this situation, the max chain length
+   * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+   * the bucket's chain exceeds this length, bucket expansion is triggered).
+   * However, setting expand_mult to a non-zero value delays bucket expansion
+   * (that would be triggered by additions to this particular bucket)
+   * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+   * (The multiplier is simply expand_mult+1). The whole idea of this
+   * multiplier is to reduce bucket expansions, since they are expensive, in
+   * situations where we know that a particular bucket tends to be overused.
+   * It is better to let its chain length grow to a longer yet-still-bounded
+   * value, than to do an O(n) bucket expansion too often.
+   */
+  unsigned expand_mult;
 
 } UT_hash_bucket;
 
@@ -894,47 +976,47 @@ typedef struct UT_hash_bucket {
 #define HASH_BLOOM_SIGNATURE 0xb12220f2
 
 typedef struct UT_hash_table {
-   UT_hash_bucket *buckets;
-   unsigned num_buckets, log2_num_buckets;
-   unsigned num_items;
-   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
-   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+  UT_hash_bucket *buckets;
+  unsigned num_buckets, log2_num_buckets;
+  unsigned num_items;
+  struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+  ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
 
-   /* in an ideal situation (all buckets used equally), no bucket would have
-    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
-   unsigned ideal_chain_maxlen;
+  /* in an ideal situation (all buckets used equally), no bucket would have
+   * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+  unsigned ideal_chain_maxlen;
 
-   /* nonideal_items is the number of items in the hash whose chain position
-    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
-    * hash distribution; reaching them in a chain traversal takes >ideal steps */
-   unsigned nonideal_items;
+  /* nonideal_items is the number of items in the hash whose chain position
+   * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+   * hash distribution; reaching them in a chain traversal takes >ideal steps */
+  unsigned nonideal_items;
 
-   /* ineffective expands occur when a bucket doubling was performed, but
-    * afterward, more than half the items in the hash had nonideal chain
-    * positions. If this happens on two consecutive expansions we inhibit any
-    * further expansion, as it's not helping; this happens when the hash
-    * function isn't a good fit for the key domain. When expansion is inhibited
-    * the hash will still work, albeit no longer in constant time. */
-   unsigned ineff_expands, noexpand;
+  /* ineffective expands occur when a bucket doubling was performed, but
+   * afterward, more than half the items in the hash had nonideal chain
+   * positions. If this happens on two consecutive expansions we inhibit any
+   * further expansion, as it's not helping; this happens when the hash
+   * function isn't a good fit for the key domain. When expansion is inhibited
+   * the hash will still work, albeit no longer in constant time. */
+  unsigned ineff_expands, noexpand;
 
-   uint32_t signature; /* used only to find hash tables in external analysis */
+  uint32_t signature; /* used only to find hash tables in external analysis */
 #ifdef HASH_BLOOM
-   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
-   uint8_t *bloom_bv;
-   char bloom_nbits;
+  uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+  uint8_t *bloom_bv;
+  char bloom_nbits;
 #endif
 
 } UT_hash_table;
 
 typedef struct UT_hash_handle {
-   struct UT_hash_table *tbl;
-   void *prev;                       /* prev element in app order      */
-   void *next;                       /* next element in app order      */
-   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
-   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
-   void *key;                        /* ptr to enclosing struct's key  */
-   unsigned keylen;                  /* enclosing struct's key len     */
-   unsigned hashv;                   /* result of hash-fcn(key)        */
+  struct UT_hash_table *tbl;
+  void *prev;                     /* prev element in app order      */
+  void *next;                     /* next element in app order      */
+  struct UT_hash_handle *hh_prev; /* previous hh in bucket order    */
+  struct UT_hash_handle *hh_next; /* next hh in bucket order        */
+  void *key;                      /* ptr to enclosing struct's key  */
+  unsigned keylen;                /* enclosing struct's key len     */
+  unsigned hashv;                 /* result of hash-fcn(key)        */
 } UT_hash_handle;
 
 #endif /* UTHASH_H */

--- a/op2/c/src/mpi/op_mpi_core.c
+++ b/op2/c/src/mpi/op_mpi_core.c
@@ -553,12 +553,11 @@ void op_halo_create() {
       for (int m = 0; m < OP_map_index; m++) { // for each maping table
         op_map map = OP_map_list[m];
 
-        if (compare_sets(map->from, set) == 1) // need to select mappings
-        // FROM this set
-        {
+        if (compare_sets(map->from, set) == 1) { // need to select mappings
+                                                 // FROM this set
           int part, local_index;
           for (int j = 0; j < map->dim; j++) { // for each element
-            // pointed at by this entry
+                                               // pointed at by this entry
             part = get_partition(map->map[e * map->dim + j],
                                  part_range[map->to->index], &local_index,
                                  comm_size);
@@ -679,7 +678,7 @@ void op_halo_create() {
     for (int i = 0; i < i_list->ranks_size; i++) {
       // printf("\n imported on to %d map %10s, number of elements of size %d |
       // recieving: ",
-      //    my_rank, map->name, i_list->size);
+      // my_rank, map->name, i_list->size);
       MPI_Recv(
           &(OP_map_list[map->index]->map[init + i_list->disps[i] * map->dim]),
           map->dim * i_list->sizes[i], MPI_INT, i_list->ranks[i], m,
@@ -717,16 +716,16 @@ void op_halo_create() {
       op_map map = OP_map_list[m];
       halo_list exec_map_list = OP_import_exec_list[map->from->index];
 
-      if (compare_sets(map->to, set) ==
-          1) // need to select mappings TO this set
-      {
+      if (compare_sets(map->to, set) == 1) { // need to select
+                                             // mappings TO this set
+
         // for each entry in this mapping table: original+execlist
         int len = map->from->size + exec_map_list->size;
         for (int e = 0; e < len; e++) {
           int part;
           int local_index;
           for (int j = 0; j < map->dim; j++) { // for each element pointed
-            // at by this entry
+                                               // at by this entry
             part = get_partition(map->map[e * map->dim + j],
                                  part_range[map->to->index], &local_index,
                                  comm_size);
@@ -838,9 +837,9 @@ void op_halo_create() {
       d++; // increase tag to do mpi comm for the next op_dat
       op_dat dat = item->dat;
 
-      if (compare_sets(set, dat->set) ==
-          1) // if this data array is defined on this set
-      {
+      if (compare_sets(set, dat->set) == 1) { // if this data array
+                                              // is defined on this set
+
         // printf("on rank %d, The data array is %10s\n",my_rank,dat->name);
         MPI_Request request_send[e_list->ranks_size];
 
@@ -899,9 +898,9 @@ void op_halo_create() {
       d++; // increase tag to do mpi comm for the next op_dat
       op_dat dat = item->dat;
 
-      if (compare_sets(set, dat->set) == 1) // if this data array is
-      // defined on this set
-      {
+      if (compare_sets(set, dat->set) == 1) { // if this data array is
+                                              // defined on this set
+
         // printf("on rank %d, The data array is %10s\n",my_rank,dat->name);
         MPI_Request request_send[e_list->ranks_size];
 
@@ -950,9 +949,9 @@ void op_halo_create() {
     for (int m = 0; m < OP_map_index; m++) { // for each maping table
       op_map map = OP_map_list[m];
 
-      if (compare_sets(map->to, set) ==
-          1) // need to select mappings TO this set
-      {
+      if (compare_sets(map->to, set) == 1) { // need to select
+                                             // mappings TO this set
+
         halo_list exec_set_list = OP_import_exec_list[set->index];
         halo_list nonexec_set_list = OP_import_nonexec_list[set->index];
 
@@ -962,7 +961,7 @@ void op_halo_create() {
         int len = map->from->size + exec_map_list->size;
         for (int e = 0; e < len; e++) {
           for (int j = 0; j < map->dim; j++) { // for each element
-            // pointed at by this entry
+                                               // pointed at by this entry
             int part;
             int local_index = 0;
             part = get_partition(map->map[e * map->dim + j],
@@ -1109,9 +1108,8 @@ void op_halo_create() {
       for (int m = 0; m < OP_map_index; m++) { // for each set
         op_map map = OP_map_list[m];
 
-        if (compare_sets(map->from, set) == 1) // if this mapping is
-        // defined from this set
-        {
+        if (compare_sets(map->from, set) == 1) { // if this mapping is
+                                                 // defined from this set
           int *new_map = (int *)xmalloc(set->size * map->dim * sizeof(int));
           for (int i = 0; i < count; i++) {
             memcpy(&new_map[i * map->dim],
@@ -1169,7 +1167,7 @@ void op_halo_create() {
     int len = map->from->size + exec_map_list->size;
     for (int e = 0; e < len; e++) {
       for (int j = 0; j < map->dim; j++) { // for each element pointed
-        // at by this entry
+                                           // at by this entry
         if (map->map[e * map->dim + j] < map->to->size) {
           int index = binary_search(core_elems[map->to->index],
                                     map->map[e * map->dim + j], 0,
@@ -1226,9 +1224,9 @@ void op_halo_create() {
       op_free(OP_part_list[set->index]->g_index);
       OP_part_list[set->index]->g_index = temp;
     }
-  } else // OP_part_list exists (i.e. a partitioning has been done)
-  // update the seperation of elements
-  {
+  } else { // OP_part_list exists (i.e. a partitioning has been done)
+           // update the seperation of elements
+
     for (int s = 0; s < OP_set_index; s++) { // for each set
       op_set set = OP_set_list[s];
 
@@ -1960,9 +1958,9 @@ void op_halo_permap_create() {
     TAILQ_FOREACH(item, &OP_dat_list, entries) {
       op_dat dat = item->dat;
       // NJH
-      if (compare_sets(set, dat->set) ==
-          1) // if this data array is defined on this set
-      {
+      if (compare_sets(set, dat->set) == 1) { // if this data array
+                                              // is defined on this set
+
         halo_list nonexec_e_list = OP_export_nonexec_list[i];
         ((op_mpi_buffer)(dat->mpi_buffer))->buf_nonexec = (char *)xrealloc(
             ((op_mpi_buffer)(dat->mpi_buffer))->buf_nonexec,
@@ -2656,9 +2654,8 @@ op_dat op_mpi_get_data(op_dat dat) {
       (int *)xmalloc(sizeof(int) * (dat->set->size + pi_list->size));
 
   count = 0;
-  for (int i = 0; i < dat->set->size;
-       i++) // iterate over old size of the g_index array
-  {
+  for (int i = 0; i < dat->set->size; i++) { // iterate over old
+                                             // size of the g_index array
     if (OP_part_list[dat->set->index]->elem_part[i] == my_rank) {
       new_g_index[count] = OP_part_list[dat->set->index]->g_index[i];
       count++;

--- a/op2/c/src/mpi/op_mpi_cuda_decl.c
+++ b/op2/c/src/mpi/op_mpi_cuda_decl.c
@@ -164,8 +164,8 @@ op_dat op_decl_dat_temp_char(op_set set, int dim, char const *type, int size,
   int set_size = set->size + OP_import_exec_list[set->index]->size +
                  OP_import_nonexec_list[set->index]->size;
 
-  dat->data =
-      (char *)xcalloc(set_size * dim * size, 1); // initialize data bits to 0
+  // initialize data bits to 0
+  dat->data = (char *)xcalloc(set_size * dim * size, 1);
   dat->user_managed = 0;
 
   // transpose

--- a/op2/c/src/mpi/op_mpi_cuda_kernels.cu
+++ b/op2/c/src/mpi/op_mpi_cuda_kernels.cu
@@ -31,7 +31,9 @@
  */
 
 #define MPICH_IGNORE_CXX_SEEK
+
 #include <op_lib_mpi.h>
+
 #include <op_lib_c.h>
 
 __global__ void export_halo_gather(int *list, char *dat, int copy_size,

--- a/op2/c/src/mpi/op_mpi_cuda_rt_support.c
+++ b/op2/c/src/mpi/op_mpi_cuda_rt_support.c
@@ -544,7 +544,7 @@ void op_exchange_halo_partial(op_arg *arg, int exec_flag) {
     halo_list imp_nonexec_list = OP_import_nonexec_permap[arg->map->index];
     halo_list exp_nonexec_list = OP_export_nonexec_permap[arg->map->index];
     //-------exchange nonexec elements related to this data array and
-    //map--------
+    // map--------
 
     // sanity checks
     if (compare_sets(imp_nonexec_list->set, dat->set) == 0) {

--- a/op2/c/src/mpi/op_mpi_decl.c
+++ b/op2/c/src/mpi/op_mpi_decl.c
@@ -117,8 +117,8 @@ op_dat op_decl_dat_temp_char(op_set set, int dim, char const *type, int size,
   int halo_size = OP_import_exec_list[set->index]->size +
                   OP_import_nonexec_list[set->index]->size;
 
-  dat->data = (char *)calloc((set->size + halo_size) * dim * size,
-                             1); // initialize data bits to 0
+  // initialize data bits to 0
+  dat->data = (char *)calloc((set->size + halo_size) * dim * size, 1);
   dat->user_managed = 0;
 
   // need to allocate mpi_buffers for this new temp_dat

--- a/op2/c/src/mpi/op_mpi_part_core.c
+++ b/op2/c/src/mpi/op_mpi_part_core.c
@@ -1046,9 +1046,8 @@ static void migrate_all(int my_rank, int comm_size) {
       d++; // increase tag to do mpi comm for the next op_dat
       op_dat dat = item->dat;
 
-      if (compare_sets(dat->set, set) ==
-          1) // this data array is defines on this set
-      {
+      if (compare_sets(dat->set, set) == 1) { // this data array
+                                              // is defined on this set
 
         // prepare bits of the data array to be exported
         char **sbuf = (char **)xmalloc(exp->ranks_size * sizeof(char *));
@@ -1125,9 +1124,9 @@ static void migrate_all(int my_rank, int comm_size) {
     for (int m = 0; m < OP_map_index; m++) { // for each maping table
       op_map map = OP_map_list[m];
 
-      if (compare_sets(map->from, set) ==
-          1) // need to select mappings FROM this set
-      {
+      if (compare_sets(map->from, set) == 1) { // need to select
+                                               // mappings FROM this set
+
         // prepare bits of the mapping tables to be exported
         int **sbuf = (int **)xmalloc(exp->ranks_size * sizeof(int *));
 
@@ -1169,9 +1168,8 @@ static void migrate_all(int my_rank, int comm_size) {
             (int *)xmalloc(sizeof(int) * (set->size + imp->size) * map->dim);
 
         count = 0;
-        for (int i = 0; i < map->from->size;
-             i++) // iterate over old size of the maping table
-        {
+        for (int i = 0; i < map->from->size; i++) { // iterate over old size
+                                                    // of the maping table
           if (OP_part_list[map->from->index]->elem_part[i] == my_rank) {
             memcpy(&new_map[count * map->dim],
                    (void *)&OP_map_list[map->index]->map[map->dim * i],
@@ -1239,9 +1237,8 @@ static void migrate_all(int my_rank, int comm_size) {
     int *new_g_index = (int *)xmalloc(sizeof(int) * (set->size + imp->size));
 
     count = 0;
-    for (int i = 0; i < set->size;
-         i++) // iterate over old size of the g_index array
-    {
+    for (int i = 0; i < set->size; i++) { // iterate over old
+                                          // size of the g_index array
       if (OP_part_list[set->index]->elem_part[i] == my_rank) {
         new_g_index[count] = OP_part_list[set->index]->g_index[i];
         count++;
@@ -1509,6 +1506,7 @@ void op_partition_random(op_set primary_set) {
   renumber_maps(my_rank, comm_size);
 
   op_timers(&cpu_t2, &wall_t2); // timer stop for partitioning
+
   // printf time for partitioning
   time = wall_t2 - wall_t1;
   MPI_Reduce(&time, &max_time, 1, MPI_DOUBLE, MPI_MAX, MPI_ROOT, OP_PART_WORLD);
@@ -1660,6 +1658,7 @@ void op_partition_geom(op_dat coords) {
   renumber_maps(my_rank, comm_size);
 
   op_timers(&cpu_t2, &wall_t2); // timer stop for partitioning
+
   // printf time for partitioning
   time = wall_t2 - wall_t1;
   MPI_Reduce(&time, &max_time, 1, MPI_DOUBLE, MPI_MAX, MPI_ROOT, OP_PART_WORLD);
@@ -1737,11 +1736,11 @@ void op_partition_kway(op_map primary_map) {
   int cap = 1000;
   int *list = (int *)xmalloc(cap * sizeof(int)); // temp list
 
-  for (int e = 0; e < primary_map->from->size;
-       e++) { // for each maping table entry
+  for (int e = 0; e < primary_map->from->size; e++) { // for each
+                                                      // maping table entry
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[e * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -1859,8 +1858,8 @@ void op_partition_kway(op_map primary_map) {
   // list
   for (int i = 0; i < primary_map->from->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -1882,8 +1881,8 @@ void op_partition_kway(op_map primary_map) {
   // list
   for (int i = 0; i < imp_list->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(foreign_maps[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2158,11 +2157,11 @@ void op_partition_geomkway(op_dat coords, op_map primary_map) {
   int cap = 1000;
   int *list = (int *)xmalloc(cap * sizeof(int)); // temp list
 
-  for (int e = 0; e < primary_map->from->size;
-       e++) { // for each maping table entry
+  for (int e = 0; e < primary_map->from->size; e++) { // for each
+                                                      // maping table entry
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[e * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2280,8 +2279,8 @@ void op_partition_geomkway(op_dat coords, op_map primary_map) {
   // list
   for (int i = 0; i < primary_map->from->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2303,8 +2302,8 @@ void op_partition_geomkway(op_dat coords, op_map primary_map) {
   // list
   for (int i = 0; i < imp_list->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(foreign_maps[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2721,11 +2720,11 @@ void op_partition_ptscotch(op_map primary_map) {
   int cap = 1000;
   int *list = (int *)xmalloc(cap * sizeof(int)); // temp list
 
-  for (int e = 0; e < primary_map->from->size;
-       e++) { // for each maping table entry
+  for (int e = 0; e < primary_map->from->size; e++) { // for each
+                                                      // maping table entry
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[e * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2847,8 +2846,8 @@ void op_partition_ptscotch(op_map primary_map) {
   // list
   for (int i = 0; i < primary_map->from->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(primary_map->map[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);
@@ -2870,8 +2869,8 @@ void op_partition_ptscotch(op_map primary_map) {
   // list
   for (int i = 0; i < imp_list->size; i++) {
     int part, local_index;
-    for (int j = 0; j < primary_map->dim;
-         j++) { // for each element pointed at by this entry
+    for (int j = 0; j < primary_map->dim; j++) { // for each element
+                                                 // pointed at by this entry
       part = get_partition(foreign_maps[i * primary_map->dim + j],
                            part_range[primary_map->to->index], &local_index,
                            comm_size);

--- a/op2/c/src/mpi/op_mpi_rt_support.c
+++ b/op2/c/src/mpi/op_mpi_rt_support.c
@@ -209,7 +209,7 @@ void op_exchange_halo_partial(op_arg *arg, int exec_flag) {
     halo_list imp_nonexec_list = OP_import_nonexec_permap[arg->map->index];
     halo_list exp_nonexec_list = OP_export_nonexec_permap[arg->map->index];
     //-------exchange nonexec elements related to this data array and
-    //map--------
+    // map--------
 
     // sanity checks
     if (compare_sets(imp_nonexec_list->set, dat->set) == 0) {

--- a/scripts/pre-commit-check_formatting.sh
+++ b/scripts/pre-commit-check_formatting.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import subprocess
+retcode = subprocess.call("which git-clang-format > /dev/null", shell=True)
+if retcode == 0:
+  output = subprocess.check_output(["git", "clang-format", "--diff"])
+  print output
+  if output not in ['no modified files to format\n', 'clang-format did not modify any files\n']:
+    print "Need changes to adhere to OP2 coding guidelines."
+    print "Run git clang-format -f, check if the formatting is acceptable, then commit.\n"
+    exit(1)
+  else:
+    exit(0)
+else:
+  print 'Cannot find git-clang-format in PATH'
+  print 'Install and add git-clang-format to PATH to format code changes to conform to code formatting guidelines'

--- a/scripts/pre-commit-white_spaces.sh
+++ b/scripts/pre-commit-white_spaces.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+  against=HEAD
+else
+  # Initial commit: diff against an empty tree object
+  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+  # Note that the use of brackets around a tr range is ok here, (it's
+  # even required, for portability to Solaris 10's /usr/bin/tr), since
+  # the square bracket bytes happen to fall in the designated range.
+  test $(git diff --cached --name-only --diff-filter=A -z $against |
+    LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+  cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+  exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Call precommit hook scripts.
+$OP2_INSTALL_PATH/../scripts/pre-commit-white_spaces.sh
+rc=$?;if [ $rc != 0 ]; then echo "White spaces Found - Aborting Commit";exit $rc; fi;
+$OP2_INSTALL_PATH/../scripts/pre-commit-check_formatting.sh


### PR DESCRIPTION
This pull-request adds scripts to call git clang-format as a pre commit hook. This is so that developers submitting code to OP2 can now correct the code formatting using clang-format before a commit. There is also some very minor fixes to the formatting of code in the back-end op2 C libs.