### PR TITLE
C Python translator performs better search for kernel declaration.

### DIFF
--- a/apps/c/reduction/reduction.cpp
+++ b/apps/c/reduction/reduction.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv) {
   op_timers(&cpu_t2, &wall_t2);
   op_timing_output();
 
+  op_printf("Max total runtime = %f\n", wall_t2 - wall_t1);
+
   op_exit();
 
   free(cell);

--- a/apps/c/reduction/reduction_mpi.cpp
+++ b/apps/c/reduction/reduction_mpi.cpp
@@ -312,6 +312,7 @@ int main(int argc, char **argv) {
   op_timers(&cpu_t2, &wall_t2);
 
   op_timing_output();
+  op_printf("Max total runtime = %f\n", wall_t2 - wall_t1);
 
   op_exit();
 

--- a/apps/c/reduction/reduction_mpi_op.cpp
+++ b/apps/c/reduction/reduction_mpi_op.cpp
@@ -334,6 +334,7 @@ int main(int argc, char **argv) {
   op_timers(&cpu_t2, &wall_t2);
 
   op_timing_output();
+  op_printf("Max total runtime = %f\n", wall_t2 - wall_t1);
 
   op_exit();
 

--- a/apps/c/reduction/reduction_op.cpp
+++ b/apps/c/reduction/reduction_op.cpp
@@ -198,6 +198,8 @@ int main(int argc, char **argv) {
   op_timers(&cpu_t2, &wall_t2);
   op_timing_output();
 
+  op_printf("Max total runtime = %f\n", wall_t2 - wall_t1);
+
   op_exit();
 
   free(cell);

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -6,7 +6,7 @@
 
 #exit script if any error is encountered during the build or
 #application executions.
-#set -e
+set -e
 
 function validate {
   $1 > perf_out

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -720,11 +720,33 @@ def main():
                 kernels[nk]["decl_filepath"] = src_file
                 kernels[nk]["decl_filename"] = os.path.basename(src_file)
 
+    for nk in xrange(0,len(kernels)):
+        name = kernels[nk]["name"]
+        if not "decl_filepath" in kernels[nk].keys():
+            ## Kernel not found in command-line supplied files, but maybe 
+            ## its declaration is in a file with the same name:
+            src_file = kernels[nk]["name"] + ".h"
+            if os.path.isfile(src_file):
+                f = open(src_file, 'r')
+                text = f.read()
+
+                inline_impl_pattern = r'inline[ \n]+void[ \n]+'+name+'\('
+                matches = re.findall(inline_impl_pattern, text)
+                if len(matches) == 1:
+                    kernels[nk]["decl_filepath"] = os.path.join(os.getcwd(), src_file)
+                    kernels[nk]["decl_filename"] = src_file
+                    continue
+                decl_pattern = r'([$\n]+)(void[ \n]+'+name+'\([ \n]*'+'[ \nA-Za-z0-9\*\_\.,#]+\);)'
+                matches = re.findall(decl_pattern, text)
+                if len(matches) == 1:
+                    kernels[nk]["decl_filepath"] = os.path.join(os.getcwd(), src_file)
+                    kernels[nk]["decl_filename"] = src_file
+
     fail = False
     for nk in xrange(0,len(kernels)):
         if not "decl_filepath" in kernels[nk].keys():
             fail = True
-            print("Implementation not found for kernel " + kernels[nk]["name"])
+            print("Delcaration not found for kernel " + kernels[nk]["name"])
     if fail:
         exit(2)
 

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -708,13 +708,13 @@ def main():
 
         for nk in xrange(0,len(kernels)):
             name = kernels[nk]["name"]
-            inline_impl_pattern = r'inline[ \n]+void[ \n]+'+name+'\([ \n]'
+            inline_impl_pattern = r'inline[ \n]+void[ \n]+'+name+'\('
             matches = re.findall(inline_impl_pattern, text)
             if len(matches) == 1:
                 kernels[nk]["decl_filepath"] = src_file
                 kernels[nk]["decl_filename"] = os.path.basename(src_file)
                 continue
-            decl_pattern = r'([$\n]+)(void[ \n]+'+name+'\([ \n]'+'[ \nA-Za-z0-9\*\_,]+\);)'
+            decl_pattern = r'([$\n]+)(void[ \n]+'+name+'\([ \n]*'+'[ \nA-Za-z0-9\*\_\.,#]+\);)'
             matches = re.findall(decl_pattern, text)
             if len(matches) == 1:
                 kernels[nk]["decl_filepath"] = src_file

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -698,6 +698,36 @@ def main():
         f.close()
     # end of loop over input source files
 
+    ## Loop over input source files again, but this time to find 
+    ## the header file for each kernel. No need to assume that 
+    ## header file is named after the kernel:
+    for a in range(1, len(sys.argv)):
+        src_file = str(sys.argv[a])
+        f = open(src_file, 'r')
+        text = f.read()
+
+        for nk in xrange(0,len(kernels)):
+            name = kernels[nk]["name"]
+            inline_impl_pattern = r'inline[ \n]+void[ \n]+'+name+'\([ \n]'
+            matches = re.findall(inline_impl_pattern, text)
+            if len(matches) == 1:
+                kernels[nk]["decl_filepath"] = src_file
+                kernels[nk]["decl_filename"] = os.path.basename(src_file)
+                continue
+            decl_pattern = r'([$\n]+)(void[ \n]+'+name+'\([ \n]'+'[ \nA-Za-z0-9\*\_,]+\);)'
+            matches = re.findall(decl_pattern, text)
+            if len(matches) == 1:
+                kernels[nk]["decl_filepath"] = src_file
+                kernels[nk]["decl_filename"] = os.path.basename(src_file)
+
+    fail = False
+    for nk in xrange(0,len(kernels)):
+        if not "decl_filepath" in kernels[nk].keys():
+            fail = True
+            print("Implementation not found for kernel " + kernels[nk]["name"])
+    if fail:
+        exit(2)
+
     #  errors and warnings
 
     if ninit == 0:

--- a/translator/c/python/op2_gen_cuda_simple.py
+++ b/translator/c/python/op2_gen_cuda_simple.py
@@ -122,6 +122,7 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filepath = kernels[nk]['decl_filepath']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -278,20 +279,7 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets):
           break
 
     comm('user function')
-    found = 0
-    for files in glob.glob( "*.h" ):
-      f = open( files, 'r' )
-      for line in f:
-        match = re.search(r''+'\\b'+name+'\\b', line)
-        if match :
-          file_name = f.name
-          found = 1;
-          break
-      if found == 1:
-        break;
-
-    if found == 0:
-      print "COUND NOT FIND KERNEL", name
+    file_name = decl_filepath
 
     f = open(file_name, 'r')
     kernel_text = f.read()

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -171,6 +171,7 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filepath = kernels[nk]['decl_filepath']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -292,20 +293,7 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 # First original version
 #
     comm('user function')
-    found = 0
-    for files in glob.glob( "*.h" ):
-      f = open( files, 'r' )
-      for line in f:
-        match = re.search(r''+'\\b'+name+'\\b', line)
-        if match :
-          file_name = f.name
-          found = 1;
-          break
-      if found == 1:
-        break;
-
-    if found == 0:
-      print "COUND NOT FIND KERNEL", name
+    file_name = decl_filepath
 
     f = open(file_name, 'r')
     kernel_text = f.read()

--- a/translator/c/python/op2_gen_openacc.py
+++ b/translator/c/python/op2_gen_openacc.py
@@ -116,6 +116,7 @@ def op2_gen_openacc(master, date, consts, kernels):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filepath = kernels[nk]['decl_filepath']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -247,20 +248,7 @@ def op2_gen_openacc(master, date, consts, kernels):
           break
 
     comm('user function')
-    found = 0
-    for files in glob.glob( "*.h" ):
-      f = open( files, 'r' )
-      for line in f:
-        match = re.search(r''+'\\b'+name+'\\b', line)
-        if match :
-          file_name = f.name
-          found = 1;
-          break
-      if found == 1:
-        break;
-
-    if found == 0:
-      print "COUND NOT FIND KERNEL", name
+    file_name = decl_filepath
 
     f = open(file_name, 'r')
     kernel_text = f.read()

--- a/translator/c/python/op2_gen_openmp.py
+++ b/translator/c/python/op2_gen_openmp.py
@@ -111,6 +111,7 @@ def op2_gen_openmp(master, date, consts, kernels):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filename = kernels[nk]['decl_filename']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -221,7 +222,7 @@ def op2_gen_openmp(master, date, consts, kernels):
     if FORTRAN:
       code('include '+name+'.inc')
     elif CPP:
-      code('#include "'+name+'.h"')
+      code('#include "'+decl_filename+'"')
 
     comm('')
     comm(' x86 kernel function')

--- a/translator/c/python/op2_gen_openmp_simple.py
+++ b/translator/c/python/op2_gen_openmp_simple.py
@@ -115,6 +115,7 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filename = kernels[nk]['decl_filename']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -231,7 +232,7 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
     if FORTRAN:
       code('include '+name+'.inc')
     elif CPP:
-      code('#include "'+name+'.h"')
+      code('#include "'+decl_filename+'"')
 
 ##########################################################################
 # then C++ stub function

--- a/translator/c/python/op2_gen_seq.py
+++ b/translator/c/python/op2_gen_seq.py
@@ -114,6 +114,7 @@ def op2_gen_seq(master, date, consts, kernels):
     idxs  = kernels[nk]['idxs']
     inds  = kernels[nk]['inds']
     soaflags = kernels[nk]['soaflags']
+    decl_filename = kernels[nk]['decl_filename']
 
     ninds   = kernels[nk]['ninds']
     inddims = kernels[nk]['inddims']
@@ -230,7 +231,7 @@ def op2_gen_seq(master, date, consts, kernels):
     if FORTRAN:
       code('include '+name+'.inc')
     elif CPP:
-      code('#include "'+name+'.h"')
+      code('#include "'+decl_filename+'"')
 
 ##########################################################################
 # then C++ stub function


### PR DESCRIPTION
The C Python translator currently requires that a kernel declaration be in a header file with the same filename, restricting the developer's ability to organise code. This branch removes that requirement, as the translator can now search for a kernel declaration or inlined implementation in the provided files.

Validated to be correct with Airfoil HDF5 and Mini-Hydra.