### PR TITLE
Feature/translator pickup c defs

### DIFF
--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -104,8 +104,8 @@ def self_evaluate_macro_defs(macro_defs):
     while substitutions_performed:
         substitutions_performed = False
         for k in macro_defs.keys():
-            val = macro_defs[k]
-            m = re.search(numeric_pattern, val)
+            k_val = macro_defs[k]
+            m = re.search(numeric_pattern, k_val)
             if m != None:
                 ## This macro definiton is numeric
                 continue
@@ -113,13 +113,14 @@ def self_evaluate_macro_defs(macro_defs):
             ## If value of key 'k' depends on value of other 
             ## keys, then substitute in value:
             for k2 in macro_defs.keys():
-                pattern = r'' + k2 + '(?!A-Z)(?!_)'
-                m = re.search(pattern, val)
+                pattern = r'' + '(?!a-zA-Z0-9_)' + k2 + '(?!a-zA-Z0-9_)'
+                m = re.search(pattern, k_val)
 
                 if m != None:
-                    # print("Performing a substitution of '" + k2 + "' -> '" + macro_defs[k2] + "' into " + val)
-                    macro_defs[k] = val.replace(k2, macro_defs[k2])
-                    val = macro_defs[k]
+                    k2_val = macro_defs[k2]
+                    # print("Performing a substitution of '" + k2 + "' -> '" + k2_val + "' into " + k_val)
+                    # macro_defs[k] = k_val.replace(k2, k2_val)
+                    macro_defs[k] = re.sub(pattern, k2_val, k_val)
                     substitutions_performed = True
 
     ## Evaluate any mathematical expressions:

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -114,14 +114,14 @@ def self_evaluate_macro_defs(macro_defs):
             ## If value of key 'k' depends on value of other 
             ## keys, then substitute in value:
             for k2 in macro_defs.keys():
-                pattern = r'' + '(?!a-zA-Z0-9_)' + k2 + '(?!a-zA-Z0-9_)'
+                pattern = r'' + '(^|[^a-zA-Z0-9_])' + k2 + '($|[^a-zA-Z0-9_])'
                 m = re.search(pattern, k_val)
 
                 if m != None:
                     ## The macro "k" refers to macro "k2"
                     k2_val = macro_defs[k2]
-                    # print("Performing a substitution of '" + k2 + "' -> '" + k2_val + "' into " + k_val)
-                    macro_defs[k] = re.sub(pattern, k2_val, k_val)
+                    macro_defs[k] = re.sub(pattern, "\\g<1>"+k2_val+"\\g<2>", k_val)
+                    # print("Performing a substitution of '" + k2 + "'->'" + k2_val + "' into '" + k_val + "' to produce '" + macro_defs[k] + "'")
                     substitutions_performed = True
 
     ## Evaluate any mathematical expressions:
@@ -150,12 +150,14 @@ def evaluate_macro_defs_in_string(macro_defs, string):
         for k in macro_defs.keys():
             k_val = macro_defs[k]
 
-            k_pattern = r'' + '(?!a-zA-Z0-9_)' + k + '(?!a-zA-Z0-9_)'
+            k_pattern = r'' + r'' + '(^|[^a-zA-Z0-9_])' + k + '($|[^a-zA-Z0-9_])'
             m = re.search(k_pattern, resolved_string)
             if m != None:
                 ## "string" contains a reference to macro "k", so substitute 
                 ## in its definition:
-                resolved_string = re.sub(k_pattern, resolved_string, k_val)
+                resolved_string_new = re.sub(k_pattern, "\\g<1>"+k_val+"\\g<2>", resolved_string)
+                # print("Performing a substitution of '" + k + "'->'" + k_val + "' into '" + resolved_string + "'' to produce '" + resolved_string_new + "'")
+                resolved_string = resolved_string_new
                 substitutions_performed = True
 
 

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -27,7 +27,7 @@ xxx_kernel.cu   -- for CUDA execution
 
 plus a master kernel file of the form
 
-file1_kernels.cpp  -- for OpenMP x86 execution
+file1_kernels.cpp  -- for OpenMP x86 execution`
 file1_kernels.cu   -- for CUDA execution
 """
 
@@ -500,20 +500,7 @@ def main():
 
             for m in range(0, nargs):
                 argm = loop_args[i]['args'][m]
-                if argm['dim'] in macro_defs.keys():
-                    # print("Replacing '" + argm['dim'] + "' with " + macro_defs[argm['dim']])
-                    argm['dim'] = macro_defs[argm['dim']]
-
-                    if re.search(arithmetic_regex_pattern, argm['dim']) != None:
-                        res = ""
-                        try:
-                            res = eval(argm['dim'])
-                        except:
-                            pass
-                        if type(res) != type(""):
-                            if str(res) != argm['dim']:
-                                # print("Replacing '" + argm['dim'] + "' with '" + str(res) + "'")
-                                argm['dim'] = str(res)
+                argm['dim'] = evaluate_macro_defs_in_string(macro_defs, argm['dim'])
 
                 arg_type = loop_args[i]['args'][m]['type']
                 args = loop_args[i]['args'][m]

--- a/translator/c/python/op2.py
+++ b/translator/c/python/op2.py
@@ -119,7 +119,6 @@ def self_evaluate_macro_defs(macro_defs):
                 if m != None:
                     k2_val = macro_defs[k2]
                     # print("Performing a substitution of '" + k2 + "' -> '" + k2_val + "' into " + k_val)
-                    # macro_defs[k] = k_val.replace(k2, k2_val)
                     macro_defs[k] = re.sub(pattern, k2_val, k_val)
                     substitutions_performed = True
 


### PR DESCRIPTION
If an op_par_loop() statement contains a C macro definition where op2.py expects an integer, such as for the 'dim' field, then op2.py will fail to parse the code.

To address this, op2.py has been extended with logic that searches for such definitions, evaluates the RHS if it is an arithmetic expression (such as 1+3), and substitutes the RHS into the in-memory source code.

It can be argued that applying the C preprocessor would be better, however as the resulting source code would be very different to the input, then the user could not easily relate and syntax errors encountered by op2.py back to their source code.