### PR TITLE
Add header guard to op_seq.h

### DIFF
--- a/op2/c/include/op_seq.h
+++ b/op2/c/include/op_seq.h
@@ -1,4 +1,5 @@
-
+#ifndef __OP_SEQ_H
+#define __OP_SEQ_H
 //
 // header for sequential and MPI+sequentional execution
 //
@@ -3763,3 +3764,5 @@ void op_par_loop(void (*kernel)(T0 *, T1 *, T2 *, T3 *, T4 *, T5 *, T6 *, T7 *,
     free(p_a[19]);
   }
 }
+
+#endif /* __OP_SEQ_H */


### PR DESCRIPTION
Add header guard to op_seq.h.
For generating files with OP2-Clang every code should compile. 
Current volna OP2 implementation includes op_seq.h in volna_output.h and volna_writeVTK.h (which is also included in volna_outpu.h), therefore raise errors.
