### PR TITLE
Feature/hdf5 dataset path

### DIFF
--- a/apps/c/airfoil/airfoil_hdf5/dp/Makefile
+++ b/apps/c/airfoil/airfoil_hdf5/dp/Makefile
@@ -145,7 +145,7 @@ HDF5_LIB = -L$(HDF5_INSTALL_PATH)/lib -lhdf5 -lz
 #
 # master to make all versions
 #
-ALL_TARGETS = clean airfoil_mpi airfoil_cuda airfoil_openmp airfoil_seq airfoil_mpi_genseq airfoil_mpi_cuda airfoil_mpi_cuda_hyb airfoil_mpi_openmp convert_mesh
+ALL_TARGETS = clean airfoil_mpi airfoil_cuda airfoil_openmp airfoil_seq airfoil_mpi_genseq airfoil_mpi_cuda airfoil_mpi_cuda_hyb airfoil_mpi_openmp convert_mesh_seq convert_mesh_mpi
 ifeq ($(OP2_COMPILER),pgi)
 	ALL_TARGETS += airfoil_openacc airfoil_mpi_openacc
 endif
@@ -153,7 +153,6 @@ ifeq ($(OP2_COMPILER),intel)
 	ALL_TARGETS += airfoil_mpi_vec
 endif
 
-#all: clean airfoil_mpi airfoil_cuda airfoil_openmp airfoil_seq airfoil_mpi_genseq airfoil_mpi_vec airfoil_mpi_cuda airfoil_mpi_openmp airfoil_mpi_cuda_hyb convert_mesh
 all: $(ALL_TARGETS)
 
 #
@@ -381,13 +380,18 @@ airfoil_hybkernels.o: airfoil_hybkernels.cu \
 		$(MPICPP) -DOP_HYBRID_GPU $(OMPFLAGS) $(INC) $(OP2_INC) -I $(MPI_INSTALL_PATH)/include \
                 -c -o airfoil_hybkernels2.o airfoil_hybkernels2.cpp
 		rm airfoil_hybkernels2.cpp
+
 #
 # convert ASCI new_gird.dat to HDF5 new_grid.h5
 #
 
-convert_mesh: convert_mesh.cpp
+convert_mesh_seq: convert_mesh.cpp
 	$(MPICPP) $(MPIFLAGS) convert_mesh.cpp $(OP2_INC) $(PARMETIS_INC) $(PTSCOTCH_INC) $(HDF5_INC) \
-	$(OP2_LIB) -lop2_mpi $(PARMETIS_LIB) $(PTSCOTCH_LIB) $(HDF5_LIB) -o convert_mesh
+	$(OP2_LIB) -lop2_seq -lop2_hdf5 $(PARMETIS_LIB) $(PTSCOTCH_LIB) $(HDF5_LIB) -o convert_mesh_seq
+
+convert_mesh_mpi: convert_mesh_mpi.cpp
+	$(MPICPP) $(MPIFLAGS) convert_mesh_mpi.cpp $(OP2_INC) $(PARMETIS_INC) $(PTSCOTCH_INC) $(HDF5_INC) \
+	$(OP2_LIB) -lop2_mpi $(PARMETIS_LIB) $(PTSCOTCH_LIB) $(HDF5_LIB) -o convert_mesh_mpi
 
 
 
@@ -397,4 +401,4 @@ convert_mesh: convert_mesh.cpp
 #
 
 clean:
-		rm -f airfoil_seq airfoil_openmp airfoil_cuda airfoil_mpi airfoil_mpi_genseq airfoil_mpi_vec airfoil_mpi_cuda_hyb airfoil_mpi_openmp airfoil_mpi_cuda convert_mesh airfoil_openacc airfoil_mpi_openacc *.o *.optrpt
+		rm -f airfoil_seq airfoil_openmp airfoil_cuda airfoil_mpi airfoil_mpi_genseq airfoil_mpi_vec airfoil_mpi_cuda_hyb airfoil_mpi_openmp airfoil_mpi_cuda convert_mesh_seq convert_mesh_mpi airfoil_openacc airfoil_mpi_openacc *.o *.optrpt

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
@@ -214,8 +214,17 @@ int main(int argc, char **argv) {
   op_decl_const(1, "double", &alpha);
   op_decl_const(4, "double", qinf);
 
+  /* Test functionality of fetching data of an op_dat to an HDF5 file*/
   op_fetch_data_hdf5_file(p_x_test, "test.h5");
 
+  char name[128];
+  int time = 0;
+  sprintf(name, "states_%07i", (int)(time * 100.0));
+  op_fetch_data_hdf5_file_path(p_x_test, "test.h5", name);
+  sprintf(name, "/results/states_%07i", (int)(time * 100.0));
+  op_fetch_data_hdf5_file_path(p_x_test, "test.h5", name);
+
+  /* Test functionality of dumping all the sets,maps and dats to an HDF5 file*/
   op_dump_to_hdf5(file_out);
   op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
   op_write_const_hdf5("gm1", 1, "double", (char *)&gm1, "new_grid_out.h5");

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
@@ -314,6 +314,7 @@ int main(int argc, char **argv) {
   op_map pcell = op_decl_map(cells, nodes, 4, cell, "pcell");
 
   op_dat p_bound = op_decl_dat(bedges, 1, "int", bound, "p_bound");
+  // op_dat p_x = op_decl_dat(nodes, 2, "double", x, "/group1/group2/p_x");
   op_dat p_x = op_decl_dat(nodes, 2, "double", x, "p_x");
   op_dat p_q = op_decl_dat(cells, 4, "double", q, "p_q");
   op_dat p_qold = op_decl_dat(cells, 4, "double", qold, "p_qold");
@@ -328,8 +329,12 @@ int main(int argc, char **argv) {
   op_decl_const(1, "double", &alpha);
   op_decl_const(4, "double", qinf);
 
-  op_dump_to_hdf5(file_out);
-  op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
+  op_partition("PTSCOTCH", "KWAY", edges, pecell, p_x);
+
+  op_fetch_data_hdf5_file(p_x, "test.h5");
+
+  /*op_dump_to_hdf5(file_out);*/
+  /*op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
   op_write_const_hdf5("gm1", 1, "double", (char *)&gm1, "new_grid_out.h5");
   op_write_const_hdf5("cfl", 1, "double", (char *)&cfl, "new_grid_out.h5");
   op_write_const_hdf5("eps", 1, "double", (char *)&eps, "new_grid_out.h5");
@@ -338,7 +343,7 @@ int main(int argc, char **argv) {
   op_write_const_hdf5("qinf", 4, "double", (char *)qinf, "new_grid_out.h5");
 
   // create halos - for sanity check
-  op_halo_create();
+  op_halo_create();*/
 
   op_exit();
 }

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
@@ -314,12 +314,18 @@ int main(int argc, char **argv) {
   op_map pcell = op_decl_map(cells, nodes, 4, cell, "pcell");
 
   op_dat p_bound = op_decl_dat(bedges, 1, "int", bound, "p_bound");
-  op_dat p_x = op_decl_dat(nodes, 2, "double", x, "/group3/group2/group1/p_x");
-  // op_dat p_x = op_decl_dat(nodes, 2, "double", x, "p_x");
+  op_dat p_x = op_decl_dat(nodes, 2, "double", x, "p_x");
   op_dat p_q = op_decl_dat(cells, 4, "double", q, "p_q");
   op_dat p_qold = op_decl_dat(cells, 4, "double", qold, "p_qold");
   op_dat p_adt = op_decl_dat(cells, 1, "double", adt, "p_adt");
   op_dat p_res = op_decl_dat(cells, 4, "double", res, "p_res");
+
+  /* Test out creating dataset within a nested path in an HDF5 file
+  -- Remove when needing to create correct Airfoil mesh
+  */
+  op_dat p_x_test =
+      op_decl_dat(nodes, 2, "double", x, "/group3/group2/group1/p_x_test");
+  op_map pedge_test = op_decl_map(edges, nodes, 2, edge, "/group3/pedge_test");
 
   op_decl_const(1, "double", &gam);
   op_decl_const(1, "double", &gm1);
@@ -331,10 +337,10 @@ int main(int argc, char **argv) {
 
   op_partition("PTSCOTCH", "KWAY", edges, pecell, p_x);
 
-  op_fetch_data_hdf5_file(p_x, "test.h5");
+  op_fetch_data_hdf5_file(p_x_test, "test.h5");
 
-  /*op_dump_to_hdf5(file_out);*/
-  /*op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
+  op_dump_to_hdf5(file_out);
+  op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
   op_write_const_hdf5("gm1", 1, "double", (char *)&gm1, "new_grid_out.h5");
   op_write_const_hdf5("cfl", 1, "double", (char *)&cfl, "new_grid_out.h5");
   op_write_const_hdf5("eps", 1, "double", (char *)&eps, "new_grid_out.h5");
@@ -343,7 +349,7 @@ int main(int argc, char **argv) {
   op_write_const_hdf5("qinf", 4, "double", (char *)qinf, "new_grid_out.h5");
 
   // create halos - for sanity check
-  op_halo_create();*/
+  op_halo_create();
 
   op_exit();
 }

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
@@ -314,8 +314,8 @@ int main(int argc, char **argv) {
   op_map pcell = op_decl_map(cells, nodes, 4, cell, "pcell");
 
   op_dat p_bound = op_decl_dat(bedges, 1, "int", bound, "p_bound");
-  // op_dat p_x = op_decl_dat(nodes, 2, "double", x, "/group1/group2/p_x");
-  op_dat p_x = op_decl_dat(nodes, 2, "double", x, "p_x");
+  op_dat p_x = op_decl_dat(nodes, 2, "double", x, "/group3/group2/group1/p_x");
+  // op_dat p_x = op_decl_dat(nodes, 2, "double", x, "p_x");
   op_dat p_q = op_decl_dat(cells, 4, "double", q, "p_q");
   op_dat p_qold = op_decl_dat(cells, 4, "double", qold, "p_qold");
   op_dat p_adt = op_decl_dat(cells, 1, "double", adt, "p_adt");

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh_mpi.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh_mpi.cpp
@@ -39,10 +39,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+//
+// mpi header file - included by user for user level mpi
+//
+
+#include <mpi.h>
+
 // global constants
 
 double gam, gm1, cfl, eps, mach, alpha, qinf[4];
 
+//
+// OP header file
+//
+
+#include "op_lib_cpp.h"
+#include "op_lib_mpi.h"
+#include "op_util.h"
 
 //
 // hdf5 header
@@ -56,6 +69,48 @@ double gam, gm1, cfl, eps, mach, alpha, qinf[4];
 
 #include "op_seq.h"
 
+static void scatter_double_array(double *g_array, double *l_array,
+                                 int comm_size, int g_size, int l_size,
+                                 int elem_size) {
+  int *sendcnts = (int *)op_malloc(comm_size * sizeof(int));
+  int *displs = (int *)op_malloc(comm_size * sizeof(int));
+  int disp = 0;
+
+  for (int i = 0; i < comm_size; i++) {
+    sendcnts[i] = elem_size * compute_local_size(g_size, comm_size, i);
+  }
+  for (int i = 0; i < comm_size; i++) {
+    displs[i] = disp;
+    disp = disp + sendcnts[i];
+  }
+
+  MPI_Scatterv(g_array, sendcnts, displs, MPI_DOUBLE, l_array,
+               l_size * elem_size, MPI_DOUBLE, MPI_ROOT, MPI_COMM_WORLD);
+
+  free(sendcnts);
+  free(displs);
+}
+
+static void scatter_int_array(int *g_array, int *l_array, int comm_size,
+                              int g_size, int l_size, int elem_size) {
+  int *sendcnts = (int *)op_malloc(comm_size * sizeof(int));
+  int *displs = (int *)op_malloc(comm_size * sizeof(int));
+  int disp = 0;
+
+  for (int i = 0; i < comm_size; i++) {
+    sendcnts[i] = elem_size * compute_local_size(g_size, comm_size, i);
+  }
+  for (int i = 0; i < comm_size; i++) {
+    displs[i] = disp;
+    disp = disp + sendcnts[i];
+  }
+
+  MPI_Scatterv(g_array, sendcnts, displs, MPI_INT, l_array, l_size * elem_size,
+               MPI_INT, MPI_ROOT, MPI_COMM_WORLD);
+
+  free(sendcnts);
+  free(displs);
+}
 
 static void check_scan(int items_received, int items_expected) {
   if (items_received != items_expected) {
@@ -71,6 +126,12 @@ static void check_scan(int items_received, int items_expected) {
 int main(int argc, char **argv) {
   // OP initialisation
   op_init(argc, argv, 2);
+
+  // MPI for user I/O
+  int my_rank;
+  int comm_size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
 
   int *becell, *ecell, *bound, *bedge, *edge, *cell;
   double *x, *q, *qold, *adt, *res;
@@ -110,59 +171,79 @@ int main(int argc, char **argv) {
     exit(-1);
   }
 
-  check_scan(fscanf(fp, "%d %d %d %d \n", &nnode, &ncell, &nedge, &nbedge), 4);
+  int g_nnode, g_ncell, g_nedge, g_nbedge;
+
+  check_scan(
+      fscanf(fp, "%d %d %d %d \n", &g_nnode, &g_ncell, &g_nedge, &g_nbedge), 4);
+
+  int *g_becell = 0, *g_ecell = 0, *g_bound = 0, *g_bedge = 0, *g_edge = 0,
+      *g_cell = 0;
+  double *g_x = 0, *g_q = 0, *g_qold = 0, *g_adt = 0, *g_res = 0;
 
   op_printf("reading in grid \n");
   op_printf("Global number of nodes, cells, edges, bedges = %d, %d, %d, %d\n",
-            nnode, ncell, nedge, nbedge);
+            g_nnode, g_ncell, g_nedge, g_nbedge);
 
-  cell = (int *)op_malloc(4 * ncell * sizeof(int));
-  edge = (int *)op_malloc(2 * nedge * sizeof(int));
-  ecell = (int *)op_malloc(2 * nedge * sizeof(int));
-  bedge = (int *)op_malloc(2 * nbedge * sizeof(int));
-  becell = (int *)op_malloc(nbedge * sizeof(int));
-  bound = (int *)op_malloc(nbedge * sizeof(int));
+  if (my_rank == MPI_ROOT) {
+    g_cell = (int *)op_malloc(4 * g_ncell * sizeof(int));
+    g_edge = (int *)op_malloc(2 * g_nedge * sizeof(int));
+    g_ecell = (int *)op_malloc(2 * g_nedge * sizeof(int));
+    g_bedge = (int *)op_malloc(2 * g_nbedge * sizeof(int));
+    g_becell = (int *)op_malloc(g_nbedge * sizeof(int));
+    g_bound = (int *)op_malloc(g_nbedge * sizeof(int));
 
-  x = (double *)op_malloc(2 * nnode * sizeof(double));
-  q = (double *)op_malloc(4 * ncell * sizeof(double));
-  qold = (double *)op_malloc(4 * ncell * sizeof(double));
-  res = (double *)op_malloc(4 * ncell * sizeof(double));
-  adt = (double *)op_malloc(ncell * sizeof(double));
+    g_x = (double *)op_malloc(2 * g_nnode * sizeof(double));
+    g_q = (double *)op_malloc(4 * g_ncell * sizeof(double));
+    g_qold = (double *)op_malloc(4 * g_ncell * sizeof(double));
+    g_res = (double *)op_malloc(4 * g_ncell * sizeof(double));
+    g_adt = (double *)op_malloc(g_ncell * sizeof(double));
 
-  for (int n = 0; n < nnode; n++) {
-    check_scan(fscanf(fp, "%lf %lf \n", &x[2 * n], &x[2 * n + 1]), 2);
-  }
+    for (int n = 0; n < g_nnode; n++) {
+      check_scan(fscanf(fp, "%lf %lf \n", &g_x[2 * n], &g_x[2 * n + 1]), 2);
+    }
 
-  for (int n = 0; n < ncell; n++) {
-    check_scan(fscanf(fp, "%d %d %d %d \n", &cell[4 * n], &cell[4 * n + 1],
-                      &cell[4 * n + 2], &cell[4 * n + 3]),
-               4);
-  }
+    for (int n = 0; n < g_ncell; n++) {
+      check_scan(fscanf(fp, "%d %d %d %d \n", &g_cell[4 * n],
+                        &g_cell[4 * n + 1], &g_cell[4 * n + 2],
+                        &g_cell[4 * n + 3]),
+                 4);
+    }
 
-  for (int n = 0; n < nedge; n++) {
-    check_scan(fscanf(fp, "%d %d %d %d \n", &edge[2 * n], &edge[2 * n + 1],
-                      &ecell[2 * n], &ecell[2 * n + 1]),
-               4);
-  }
+    for (int n = 0; n < g_nedge; n++) {
+      check_scan(fscanf(fp, "%d %d %d %d \n", &g_edge[2 * n],
+                        &g_edge[2 * n + 1], &g_ecell[2 * n],
+                        &g_ecell[2 * n + 1]),
+                 4);
+    }
 
-  for (int n = 0; n < nbedge; n++) {
-    check_scan(fscanf(fp, "%d %d %d %d \n", &bedge[2 * n], &bedge[2 * n + 1],
-                      &becell[n], &bound[n]),
-               4);
-  }
+    for (int n = 0; n < g_nbedge; n++) {
+      check_scan(fscanf(fp, "%d %d %d %d \n", &g_bedge[2 * n],
+                        &g_bedge[2 * n + 1], &g_becell[n], &g_bound[n]),
+                 4);
+    }
 
-  // initialise flow field and residual
+    // initialise flow field and residual
 
-  for (int n = 0; n < ncell; n++) {
-    for (int m = 0; m < 4; m++) {
-      q[4 * n + m] = qinf[m];
-      res[4 * n + m] = 0.0f;
+    for (int n = 0; n < g_ncell; n++) {
+      for (int m = 0; m < 4; m++) {
+        g_q[4 * n + m] = qinf[m];
+        g_res[4 * n + m] = 0.0f;
+      }
     }
   }
 
   fclose(fp);
 
+  nnode = compute_local_size(g_nnode, comm_size, my_rank);
+  ncell = compute_local_size(g_ncell, comm_size, my_rank);
+  nedge = compute_local_size(g_nedge, comm_size, my_rank);
+  nbedge = compute_local_size(g_nbedge, comm_size, my_rank);
 
+  op_printf(
+      "Number of nodes, cells, edges, bedges on process %d = %d, %d, %d, %d\n",
+      my_rank, nnode, ncell, nedge, nbedge);
+
+  /*Allocate memory to hold local sets, mapping tables and data*/
   cell = (int *)op_malloc(4 * ncell * sizeof(int));
   edge = (int *)op_malloc(2 * nedge * sizeof(int));
   ecell = (int *)op_malloc(2 * nedge * sizeof(int));
@@ -175,6 +256,36 @@ int main(int argc, char **argv) {
   qold = (double *)op_malloc(4 * ncell * sizeof(double));
   res = (double *)op_malloc(4 * ncell * sizeof(double));
   adt = (double *)op_malloc(ncell * sizeof(double));
+
+  /* scatter sets, mappings and data on sets*/
+  scatter_int_array(g_cell, cell, comm_size, g_ncell, ncell, 4);
+  scatter_int_array(g_edge, edge, comm_size, g_nedge, nedge, 2);
+  scatter_int_array(g_ecell, ecell, comm_size, g_nedge, nedge, 2);
+  scatter_int_array(g_bedge, bedge, comm_size, g_nbedge, nbedge, 2);
+  scatter_int_array(g_becell, becell, comm_size, g_nbedge, nbedge, 1);
+  scatter_int_array(g_bound, bound, comm_size, g_nbedge, nbedge, 1);
+
+  scatter_double_array(g_x, x, comm_size, g_nnode, nnode, 2);
+  scatter_double_array(g_q, q, comm_size, g_ncell, ncell, 4);
+  scatter_double_array(g_qold, qold, comm_size, g_ncell, ncell, 4);
+  scatter_double_array(g_res, res, comm_size, g_ncell, ncell, 4);
+  scatter_double_array(g_adt, adt, comm_size, g_ncell, ncell, 1);
+
+  /*Freeing memory allocated to gloabal arrays on rank 0
+    after scattering to all processes*/
+  if (my_rank == MPI_ROOT) {
+    free(g_cell);
+    free(g_edge);
+    free(g_ecell);
+    free(g_bedge);
+    free(g_becell);
+    free(g_bound);
+    free(g_x);
+    free(g_q);
+    free(g_qold);
+    free(g_adt);
+    free(g_res);
+  }
 
   /**------------------------END I/O  -----------------------**/
 
@@ -214,6 +325,8 @@ int main(int argc, char **argv) {
   op_decl_const(1, "double", &alpha);
   op_decl_const(4, "double", qinf);
 
+  op_partition("PTSCOTCH", "KWAY", edges, pecell, p_x);
+
   op_fetch_data_hdf5_file(p_x_test, "test.h5");
 
   op_dump_to_hdf5(file_out);
@@ -224,6 +337,9 @@ int main(int argc, char **argv) {
   op_write_const_hdf5("mach", 1, "double", (char *)&mach, "new_grid_out.h5");
   op_write_const_hdf5("alpha", 1, "double", (char *)&alpha, "new_grid_out.h5");
   op_write_const_hdf5("qinf", 4, "double", (char *)qinf, "new_grid_out.h5");
+
+  // create halos - for sanity check
+  op_halo_create();
 
   op_exit();
 }

--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh_mpi.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh_mpi.cpp
@@ -327,8 +327,17 @@ int main(int argc, char **argv) {
 
   op_partition("PTSCOTCH", "KWAY", edges, pecell, p_x);
 
+  /* Test functionality of fetching data of an op_dat to an HDF5 file*/
   op_fetch_data_hdf5_file(p_x_test, "test.h5");
 
+  char name[128];
+  int time = 0;
+  sprintf(name, "states_%07i", (int)(time * 100.0));
+  op_fetch_data_hdf5_file_path(p_x_test, "test.h5", name);
+  sprintf(name, "/results/states_%07i", (int)(time * 100.0));
+  op_fetch_data_hdf5_file_path(p_x_test, "test.h5", name);
+
+  /* Test functionality of dumping all the sets,maps and dats to an HDF5 file*/
   op_dump_to_hdf5(file_out);
   op_write_const_hdf5("gam", 1, "double", (char *)&gam, "new_grid_out.h5");
   op_write_const_hdf5("gm1", 1, "double", (char *)&gm1, "new_grid_out.h5");

--- a/op2/c/include/op_hdf5.h
+++ b/op2/c/include/op_hdf5.h
@@ -60,6 +60,8 @@ void op_write_const_hdf5(char const *name, int dim, char const *type,
                          char *const_data, char const *file_name);
 
 void op_fetch_data_hdf5_file(op_dat dat, char const *file_name);
+void op_fetch_data_hdf5_file_path(op_dat dat, char const *file_name,
+                                  char const *path_name);
 
 #ifdef __cplusplus
 }

--- a/op2/c/src/externlib/op_hdf5.c
+++ b/op2/c/src/externlib/op_hdf5.c
@@ -836,14 +836,22 @@ void op_fetch_data_hdf5(op_dat dat, char const *file_name,
 
   hsize_t dimsf[2]; // dataset dimensions
 
+  H5E_auto_t old_func;
+  void *old_client_data;
+
   if (file_exist(file_name) == 0) {
     printf("File %s does not exist .... creating file\n", file_name);
     file_id = H5Fcreate(file_name, H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
   } else {
-    printf("File %s exists .... checking for dataset and path%s in file\n",
+    printf("File %s exists .... checking for dataset and path %s in file\n",
            file_name, path_name);
     file_id = H5Fopen(file_name, H5F_ACC_RDWR, H5P_DEFAULT);
-    if (H5Lexists(file_id, path_name, H5P_DEFAULT) != 0) {
+
+    H5error_off(old_func, old_client_data);
+    herr_t status = H5Gget_objinfo(file_id, path_name, 0, NULL);
+    H5error_on(old_func, old_client_data);
+
+    if (status == 0) {
       printf("op_dat %s exists in the file ... updating data\n", path_name);
       dset_id = H5Dopen(file_id, path_name, H5P_DEFAULT);
 
@@ -958,7 +966,7 @@ void op_fetch_data_hdf5(op_dat dat, char const *file_name,
       H5Fclose(file_id);
       return;
     } else {
-      printf("op_dat %s does not exists in the file ... creating data set",
+      printf("op_dat %s does not exists in the file ... creating data set\n",
              path_name);
     }
   }
@@ -1059,6 +1067,7 @@ void op_fetch_data_hdf5(op_dat dat, char const *file_name,
 *******************************************************************************/
 
 void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
+  printf("in op_fetch_data_hdf5_file\n");
   op_fetch_data_hdf5(dat, file_name, dat->name);
 }
 

--- a/op2/c/src/externlib/op_hdf5.c
+++ b/op2/c/src/externlib/op_hdf5.c
@@ -31,10 +31,10 @@
  */
 
 /*
- * op_mpi_core.c
+ * op_hdf5.c
  *
  * Implements the HDF5 based I/O routines for the OP2 single node
- * backe end
+ * back end
  *
  * written by: Gihan R. Mudalige, (Started 10-10-2011)
  */
@@ -53,103 +53,7 @@
 
 #include <op_util.h> //just to include xmalloc routine
 
-typedef struct {
-  const char* type_str; // dataset type as string
-  hsize_t size;         // dataset size (first dimension)
-  hsize_t dim;          // element size (second dimension)
-  size_t elem_bytes;    // element byte-size
-} op_hdf5_dataset_properties;
-
-const char* op_hdf5_type_to_string(hid_t t) {
-  char* text = NULL;
-  if (H5Tequal(t, H5T_NATIVE_INT)) {
-    text = (char*)malloc(4*sizeof(char));
-    strcpy(text, "int");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LONG)) {
-    text = (char*)malloc(5*sizeof(char));
-    strcpy(text, "long");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
-    text = (char*)malloc(10*sizeof(char));
-    strcpy(text, "long long");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
-    text = (char*)malloc(6*sizeof(char));
-    strcpy(text, "float");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
-    text = (char*)malloc(7*sizeof(char));
-    strcpy(text, "double");
-  }
-  else {
-    text = (char*)malloc(13*sizeof(char));
-    strcpy(text, "UNRECOGNISED");
-  }
-
-  return (const char*)text;
-}
-
-herr_t get_dataset_properties(hid_t dset_id, op_hdf5_dataset_properties *dset_props) {
-  hid_t status;
-
-  if (dset_props == NULL) {
-    return -1;
-  }
-
-  // Get dimension and size:
-  hid_t dataspace = H5Dget_space(dset_id);
-  if (dataspace < 0) {
-    return -1;
-  }
-  int ndims = H5Sget_simple_extent_ndims(dataspace);
-  if (ndims == 0) {
-    dset_props->size = 0;
-    dset_props->dim = 0;
-    H5Sclose(dataspace);
-  } else {
-    hsize_t dims[ndims];
-    hsize_t maxdims[ndims];
-    status = H5Sget_simple_extent_dims(dataspace, dims, maxdims);
-    H5Sclose(dataspace);
-    if (status < 0) {
-      return -1;
-    }
-    dset_props->size = dims[0];
-    dset_props->dim = (ndims > 1) ? dims[1] : 1;
-  }
-
-  // Get type information:
-  hid_t t = H5Dget_type(dset_id);
-  if (t < 0) {
-    return -1;
-  }
-  dset_props->type_str = op_hdf5_type_to_string(t);
-  if (H5Tequal(t, H5T_NATIVE_INT)) {
-    dset_props->elem_bytes = sizeof(int);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LONG)) {
-    dset_props->elem_bytes = sizeof(long);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
-    dset_props->elem_bytes = sizeof(long long);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
-    dset_props->elem_bytes = sizeof(float);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
-    dset_props->elem_bytes = sizeof(double);  }
-  else {
-    size_t name_len = H5Iget_name(dset_id,NULL,0);
-    char name[name_len];
-    H5Iget_name(dset_id,name,name_len+1);
-    op_printf("Error: Do not recognise type of dataset '%s'\n", name);
-    exit(2);
-  }
-  dset_props->elem_bytes *= dset_props->dim;
-
-  return 0;
-}
+#include "op_hdf5_common.c"
 
 /*******************************************************************************
 * Routine to read an op_set from an hdf5 file
@@ -251,8 +155,7 @@ op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
   /* Save old error handler */
   H5E_auto_t old_func;
   void *old_client_data;
-  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
+  H5error_off(old_func, old_client_data);
 
   /*open data set*/
   dset_id = H5Dopen(file_id, name, H5P_DEFAULT);
@@ -260,7 +163,7 @@ op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
     printf("op_map with name : %s not found in file : %s \n", name, file);
     return NULL;
   }
-  
+
   op_hdf5_dataset_properties dset_props;
   status = get_dataset_properties(dset_id, &dset_props);
   if (status < 0) {
@@ -286,7 +189,7 @@ op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
   const char *typ = dset_props.type_str;
 
   // Restore previous error handler .. report hdf5 error stack automatically
-  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+  H5error_on(old_func, old_client_data);
 
   // Create the dataset with default properties and close dataspace.
   dset_id = H5Dopen(file_id, name, H5P_DEFAULT);
@@ -342,8 +245,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
   /* Save old error handler */
   H5E_auto_t old_func;
   void *old_client_data;
-  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
+  H5error_off(old_func, old_client_data);
 
   /*open data set*/
   dset_id = H5Dopen(file_id, name, H5P_DEFAULT);
@@ -376,7 +278,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
   size_t dat_size = dset_props.elem_bytes;
 
   // Restore previous error handler .. report hdf5 error stack automatically
-  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+  H5error_on(old_func, old_client_data);
 
   // Create the dataset with default properties
   dataspace = H5Dget_space(dset_id);
@@ -508,6 +410,9 @@ void op_dump_to_hdf5(char const *file_name) {
     dimsf[1] = map->dim;
     dataspace = H5Screate_simple(2, dimsf, NULL);
 
+    // create map path
+    create_path(map->name, file_id);
+
     // Create the dataset with default properties and write data
     if (sizeof(map->map[0]) == sizeof(int)) {
       dset_id = H5Dcreate(file_id, map->name, H5T_NATIVE_INT, dataspace,
@@ -595,6 +500,9 @@ void op_dump_to_hdf5(char const *file_name) {
     dimsf[0] = g_size;
     dimsf[1] = dat->dim;
     dataspace = H5Screate_simple(2, dimsf, NULL);
+
+    // create dateset path
+    create_path(dat->name, file_id);
 
     // Create the dataset with default properties and write data
     if (strcmp(dat->type, "double") == 0 ||
@@ -1062,6 +970,9 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
   dimsf[0] = dat->set->size;
   dimsf[1] = dat->dim;
   dataspace = H5Screate_simple(2, dimsf, NULL);
+
+  // create dataset path
+  create_path(dat->name, file_id);
 
   // Create the dataset with default properties and write data
   if ((strcmp(dat->type, "double") == 0) ||

--- a/op2/c/src/externlib/op_hdf5.c
+++ b/op2/c/src/externlib/op_hdf5.c
@@ -820,10 +820,11 @@ void op_write_const_hdf5(char const *name, int dim, char const *type,
 /*******************************************************************************
 * Routine to write an op_dat to a named hdf5 file,
 * if file does not exist, creates it
-* if the data set does not exists in file creates data set
+* if the data set given at path does not exists in file creates data set
 *******************************************************************************/
 
-void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
+void op_fetch_data_hdf5(op_dat dat, char const *file_name,
+                        char const *path_name) {
   // fetch data based on the backend
   op_fetch_data_char(dat, dat->data);
 
@@ -839,12 +840,12 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
     printf("File %s does not exist .... creating file\n", file_name);
     file_id = H5Fcreate(file_name, H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
   } else {
-    printf("File %s exists .... checking for dataset %s in file\n", file_name,
-           dat->name);
+    printf("File %s exists .... checking for dataset and path%s in file\n",
+           file_name, path_name);
     file_id = H5Fopen(file_name, H5F_ACC_RDWR, H5P_DEFAULT);
-    if (H5Lexists(file_id, dat->name, H5P_DEFAULT) != 0) {
-      printf("op_dat %s exists in the file ... updating data\n", dat->name);
-      dset_id = H5Dopen(file_id, dat->name, H5P_DEFAULT);
+    if (H5Lexists(file_id, path_name, H5P_DEFAULT) != 0) {
+      printf("op_dat %s exists in the file ... updating data\n", path_name);
+      dset_id = H5Dopen(file_id, path_name, H5P_DEFAULT);
 
       // find dat->size with available attributes
       size_t dat_size = 0;
@@ -861,7 +862,7 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
         }
       } else {
         printf("data set %s on file %s does not have attribute 'size'",
-               dat->name, file_name);
+               path_name, file_name);
         printf(" -- cannot check size ... aborting\n");
         exit(2);
       }
@@ -880,7 +881,7 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
         }
       } else {
         printf("data set %s on file %s does not have attribute 'dim'",
-               dat->name, file_name);
+               path_name, file_name);
         printf(" -- cannot check dim ... aborting\n");
         exit(2);
       }
@@ -906,7 +907,7 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
         }
       } else {
         printf("data set %s on file %s does not have attribute 'type'",
-               dat->name, file_name);
+               path_name, file_name);
         printf(" -- cannot check type ... aborting\n");
         exit(2);
       }
@@ -958,12 +959,12 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
       return;
     } else {
       printf("op_dat %s does not exists in the file ... creating data set",
-             dat->name);
+             path_name);
     }
   }
 
   //
-  // new file and new data set ...
+  // new data set ...
   //
 
   // Create the dataspace for the dataset.
@@ -972,36 +973,36 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
   dataspace = H5Screate_simple(2, dimsf, NULL);
 
   // create dataset path
-  create_path(dat->name, file_id);
+  create_path(path_name, file_id);
 
   // Create the dataset with default properties and write data
   if ((strcmp(dat->type, "double") == 0) ||
       (strcmp(dat->type, "double:soa") == 0)) {
-    dset_id = H5Dcreate(file_id, dat->name, H5T_NATIVE_DOUBLE, dataspace,
+    dset_id = H5Dcreate(file_id, path_name, H5T_NATIVE_DOUBLE, dataspace,
                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, H5S_ALL, dataspace, H5P_DEFAULT,
              dat->data);
   } else if ((strcmp(dat->type, "float") == 0) ||
              (strcmp(dat->type, "float:soa") == 0)) {
-    dset_id = H5Dcreate(file_id, dat->name, H5T_NATIVE_FLOAT, dataspace,
+    dset_id = H5Dcreate(file_id, path_name, H5T_NATIVE_FLOAT, dataspace,
                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset_id, H5T_NATIVE_FLOAT, H5S_ALL, dataspace, H5P_DEFAULT,
              dat->data);
   } else if ((strcmp(dat->type, "int") == 0) ||
              (strcmp(dat->type, "int:soa") == 0)) {
-    dset_id = H5Dcreate(file_id, dat->name, H5T_NATIVE_INT, dataspace,
+    dset_id = H5Dcreate(file_id, path_name, H5T_NATIVE_INT, dataspace,
                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, dataspace, H5P_DEFAULT,
              dat->data);
   } else if ((strcmp(dat->type, "long") == 0) ||
              (strcmp(dat->type, "long:soa") == 0)) {
-    dset_id = H5Dcreate(file_id, dat->name, H5T_NATIVE_LONG, dataspace,
+    dset_id = H5Dcreate(file_id, path_name, H5T_NATIVE_LONG, dataspace,
                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset_id, H5T_NATIVE_LONG, H5S_ALL, dataspace, H5P_DEFAULT,
              dat->data);
   } else if ((strcmp(dat->type, "long long") == 0) ||
              (strcmp(dat->type, "long long:soa") == 0)) {
-    dset_id = H5Dcreate(file_id, dat->name, H5T_NATIVE_LLONG, dataspace,
+    dset_id = H5Dcreate(file_id, path_name, H5T_NATIVE_LLONG, dataspace,
                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset_id, H5T_NATIVE_LLONG, H5S_ALL, dataspace, H5P_DEFAULT,
              dat->data);
@@ -1016,7 +1017,7 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
   /*attach attributes to dat*/
 
   // open existing data set
-  dset_id = H5Dopen(file_id, dat->name, H5P_DEFAULT);
+  dset_id = H5Dopen(file_id, path_name, H5P_DEFAULT);
 
   // create the data space for the attribute
   hsize_t dims = 1;
@@ -1049,4 +1050,26 @@ void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
   H5Sclose(dataspace);
   H5Dclose(dset_id);
   H5Fclose(file_id);
+}
+
+/*******************************************************************************
+* Routine to write an op_dat to a named hdf5 file,
+* if file does not exist, creates it
+* if the data set does not exists in file creates data set
+*******************************************************************************/
+
+void op_fetch_data_hdf5_file(op_dat dat, char const *file_name) {
+  op_fetch_data_hdf5(dat, file_name, dat->name);
+}
+
+/*******************************************************************************
+* Routine to write an op_dat to a named hdf5 file, where dataset_name is a
+* freely chosen path inside the h5-file of the dataset.
+* If file does not exist, creates it
+* If the data set does not exists in file creates data set
+*******************************************************************************/
+
+void op_fetch_data_hdf5_file_path(op_dat dat, char const *file_name,
+                                  char const *path_name) {
+  op_fetch_data_hdf5(dat, file_name, path_name);
 }

--- a/op2/c/src/externlib/op_hdf5_common.c
+++ b/op2/c/src/externlib/op_hdf5_common.c
@@ -1,0 +1,198 @@
+/*
+ * Open source copyright declaration based on BSD open source template:
+ * http://www.opensource.org/licenses/bsd-license.php
+ *
+ * This file is part of the OP2 distribution.
+ *
+ * Copyright (c) 2011, Mike Giles and others. Please see the AUTHORS file in
+ * the main source directory for a full list of copyright holders.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * The name of Mike Giles may not be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Mike Giles ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Mike Giles BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * op_hdf5_common.c
+ *
+ * Implements the common utility functions for both seq and mpi based
+ * HDF5 I/O routines for the OP2 back end
+ *
+ * written by: Gihan R. Mudalige, (Started 27-10-2017)
+ */
+
+// hdf5 header
+#include <hdf5.h>
+
+#include <op_lib_c.h>
+#include <op_lib_core.h>
+#include <op_rt_support.h>
+
+#include <op_util.h> //just to include xmalloc routine
+
+typedef struct {
+  const char *type_str; // dataset type as string
+  hsize_t size;         // dataset size (first dimension)
+  hsize_t dim;          // element size (second dimension)
+  size_t elem_bytes;    // element byte-size
+} op_hdf5_dataset_properties;
+
+/* Temporarily switch off HDF5 error handler*/
+void H5error_off(H5E_auto_t old_func, void *old_client_data) {
+  /* Save old error handler */
+  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
+  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
+}
+
+/* Restore previous error handler .. report hdf5 error stack automatically*/
+void H5error_on(H5E_auto_t old_func, void *old_client_data) {
+  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+}
+
+const char *op_hdf5_type_to_string(hid_t t) {
+  char *text = NULL;
+  if (H5Tequal(t, H5T_NATIVE_INT)) {
+    text = (char *)malloc(4 * sizeof(char));
+    strcpy(text, "int");
+  } else if (H5Tequal(t, H5T_NATIVE_LONG)) {
+    text = (char *)malloc(5 * sizeof(char));
+    strcpy(text, "long");
+  } else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
+    text = (char *)malloc(10 * sizeof(char));
+    strcpy(text, "long long");
+  } else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
+    text = (char *)malloc(6 * sizeof(char));
+    strcpy(text, "float");
+  } else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
+    text = (char *)malloc(7 * sizeof(char));
+    strcpy(text, "double");
+  } else {
+    text = (char *)malloc(13 * sizeof(char));
+    strcpy(text, "UNRECOGNISED");
+  }
+
+  return (const char *)text;
+}
+
+herr_t get_dataset_properties(hid_t dset_id,
+                              op_hdf5_dataset_properties *dset_props) {
+  hid_t status;
+
+  if (dset_props == NULL) {
+    return -1;
+  }
+
+  // Get dimension and size:
+  hid_t dataspace = H5Dget_space(dset_id);
+  if (dataspace < 0) {
+    return -1;
+  }
+  int ndims = H5Sget_simple_extent_ndims(dataspace);
+  if (ndims == 0) {
+    dset_props->size = 0;
+    dset_props->dim = 0;
+    H5Sclose(dataspace);
+  } else {
+    hsize_t dims[ndims];
+    hsize_t maxdims[ndims];
+    status = H5Sget_simple_extent_dims(dataspace, dims, maxdims);
+    H5Sclose(dataspace);
+    if (status < 0) {
+      return -1;
+    }
+    dset_props->size = dims[0];
+    dset_props->dim = (ndims > 1) ? dims[1] : 1;
+  }
+
+  // Get type information:
+  hid_t t = H5Dget_type(dset_id);
+  if (t < 0) {
+    return -1;
+  }
+  dset_props->type_str = op_hdf5_type_to_string(t);
+  if (H5Tequal(t, H5T_NATIVE_INT)) {
+    dset_props->elem_bytes = sizeof(int);
+  } else if (H5Tequal(t, H5T_NATIVE_LONG)) {
+    dset_props->elem_bytes = sizeof(long);
+  } else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
+    dset_props->elem_bytes = sizeof(long long);
+  } else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
+    dset_props->elem_bytes = sizeof(float);
+  } else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
+    dset_props->elem_bytes = sizeof(double);
+  } else {
+    size_t name_len = H5Iget_name(dset_id, NULL, 0);
+    char name[name_len];
+    H5Iget_name(dset_id, name, name_len + 1);
+    op_printf("Error: Do not recognise type of dataset '%s'\n", name);
+    exit(2);
+  }
+  dset_props->elem_bytes *= dset_props->dim;
+
+  return 0;
+}
+
+/*create path specified by map or dat ->name for a map or dataset
+  within an HDF5 file*/
+void create_path(const char *name, hid_t file_id) {
+
+  hid_t group_id;
+  herr_t status;
+  H5E_auto_t old_func;
+  void *old_client_data;
+
+  char *path = (char *)name;
+  char *ssc;
+  int k = 0;
+  int size = 50;
+  int c = 0;
+  ssc = strstr(path, "/");
+  char *buffer = (char *)xmalloc(50 * sizeof(char));
+  while (ssc) {
+    k = strlen(path) - strlen(ssc);
+    if (k > 0) {
+      char result[30];
+      strncpy(result, &path[0], k);
+      result[k] = '\0';
+      if (size <= c + k + 1) {
+        size = 2 * (size + c + k + 1);
+        buffer = (char *)xrealloc(buffer, 2 * size * sizeof(char));
+      }
+      sprintf(&buffer[c], "/%s", result);
+      c += 1 + k;
+
+      // Create a group named "/result" in the file.
+      H5error_off(old_func, old_client_data);
+      status = H5Gget_objinfo(file_id, buffer, 0, NULL);
+      H5error_on(old_func, old_client_data);
+
+      // printf("status %d, %s\n",status,buffer);
+      if (status != 0) {
+        group_id =
+            H5Gcreate2(file_id, buffer, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        status = H5Gclose(group_id);
+      }
+    }
+    path = &path[strlen(path) - strlen(ssc) + 1];
+    ssc = strstr(path, "/");
+  }
+  free(buffer);
+}

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -52,6 +52,7 @@
 #define H5Dopen_vers 2
 #define H5Acreate_vers 2
 #define H5Dcreate_vers 2
+
 // hdf5 header
 #include <hdf5.h>
 
@@ -59,121 +60,13 @@
 #include <op_hdf5.h>
 #include <op_lib_mpi.h>
 
+#include "../externlib/op_hdf5_common.c"
+
 //
 // MPI Communicator for parallel I/O
 //
 
 MPI_Comm OP_MPI_HDF5_WORLD;
-
-typedef struct {
-  const char* type_str; // dataset type as string
-  hsize_t size;         // dataset size (first dimension)
-  hsize_t dim;          // element size (second dimension)
-  size_t elem_bytes;    // element byte-size
-} op_hdf5_dataset_properties;
-
-/* Temporarily switch off HDF5 error handler*/
-void H5error_off(H5E_auto_t old_func, void *old_client_data) {
-  /* Save old error handler */
-  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
-}
-
-/* Restore previous error handler .. report hdf5 error stack automatically*/
-void H5error_on(H5E_auto_t old_func, void *old_client_data) {
-  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
-}
-
-const char* op_hdf5_type_to_string(hid_t t) {
-  char* text = NULL;
-  if (H5Tequal(t, H5T_NATIVE_INT)) {
-    text = (char*)malloc(4*sizeof(char));
-    strcpy(text, "int");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LONG)) {
-    text = (char*)malloc(5*sizeof(char));
-    strcpy(text, "long");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
-    text = (char*)malloc(10*sizeof(char));
-    strcpy(text, "long long");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
-    text = (char*)malloc(6*sizeof(char));
-    strcpy(text, "float");
-  }
-  else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
-    text = (char*)malloc(7*sizeof(char));
-    strcpy(text, "double");
-  }
-  else {
-    text = (char*)malloc(13*sizeof(char));
-    strcpy(text, "UNRECOGNISED");
-  }
-
-  return (const char*)text;
-}
-
-herr_t get_dataset_properties(hid_t dset_id, op_hdf5_dataset_properties *dset_props) {
-  hid_t status;
-
-  if (dset_props == NULL) {
-    return -1;
-  }
-
-  // Get dimension and size:
-  hid_t dataspace = H5Dget_space(dset_id);
-  if (dataspace < 0) {
-    return -1;
-  }
-  int ndims = H5Sget_simple_extent_ndims(dataspace);
-  if (ndims == 0) {
-    dset_props->size = 0;
-    dset_props->dim = 0;
-    H5Sclose(dataspace);
-  } else {
-    hsize_t dims[ndims];
-    hsize_t maxdims[ndims];
-    status = H5Sget_simple_extent_dims(dataspace, dims, maxdims);
-    H5Sclose(dataspace);
-    if (status < 0) {
-      return -1;
-    }
-    dset_props->size = dims[0];
-    dset_props->dim = (ndims > 1) ? dims[1] : 1;
-  }
-
-  // Get type information:
-  hid_t t = H5Dget_type(dset_id);
-  if (t < 0) {
-    return -1;
-  }
-  dset_props->type_str = op_hdf5_type_to_string(t);
-  if (H5Tequal(t, H5T_NATIVE_INT)) {
-    dset_props->elem_bytes = sizeof(int);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LONG)) {
-    dset_props->elem_bytes = sizeof(long);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_LLONG)) {
-    dset_props->elem_bytes = sizeof(long long);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_FLOAT)) {
-    dset_props->elem_bytes = sizeof(float);
-  }
-  else if (H5Tequal(t, H5T_NATIVE_DOUBLE)) {
-    dset_props->elem_bytes = sizeof(double);  }
-  else {
-    size_t name_len = H5Iget_name(dset_id,NULL,0);
-    char name[name_len];
-    H5Iget_name(dset_id,name,name_len+1);
-    op_printf("Error: Do not recognise type of dataset '%s'\n", name);
-    exit(2);
-  }
-  dset_props->elem_bytes *= dset_props->dim;
-
-  return 0;
-}
 
 int compute_local_size_weight(int global_size, int mpi_comm_size,
                               int mpi_rank) {
@@ -196,53 +89,6 @@ int compute_local_size_weight(int global_size, int mpi_comm_size,
   int local_size = local_end - local_start;
 
   return local_size;
-}
-
-/*create path specified by map or dat ->name for a map or dataset
-  within an HDF5 file*/
-void create_path(const char *name, hid_t file_id) {
-
-  hid_t group_id;
-  herr_t status;
-  H5E_auto_t old_func;
-  void *old_client_data;
-
-  char *path = (char *)name;
-  char *ssc;
-  int k = 0;
-  int size = 50;
-  int c = 0;
-  ssc = strstr(path, "/");
-  char *buffer = (char *)xmalloc(50 * sizeof(char));
-  while (ssc) {
-    k = strlen(path) - strlen(ssc);
-    if (k > 0) {
-      char result[30];
-      strncpy(result, &path[0], k);
-      result[k] = '\0';
-      if (size <= c + k + 1) {
-        size = 2 * (size + c + k + 1);
-        buffer = (char *)xrealloc(buffer, 2 * size * sizeof(char));
-      }
-      sprintf(&buffer[c], "/%s", result);
-      c += 1 + k;
-
-      // Create a group named "/result" in the file.
-      H5error_off(old_func, old_client_data);
-      status = H5Gget_objinfo(file_id, buffer, 0, NULL);
-      H5error_on(old_func, old_client_data);
-
-      // printf("status %d, %s\n",status,buffer);
-      if (status != 0) {
-        group_id =
-            H5Gcreate2(file_id, buffer, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        status = H5Gclose(group_id);
-      }
-    }
-    path = &path[strlen(path) - strlen(ssc) + 1];
-    ssc = strstr(path, "/");
-  }
-  free(buffer);
 }
 
 /*******************************************************************************
@@ -1522,6 +1368,41 @@ void op_fetch_data_hdf5_file(op_dat data, char const *file_name) {
   H5Sclose(dataspace);
   op_free(sizes);
 
+  /*attach attributes to dat*/
+
+  // open existing data set
+  dset_id = H5Dopen(file_id, dat->name, H5P_DEFAULT);
+
+  // create the data space for the attribute
+  hsize_t dims = 1;
+  dataspace = H5Screate_simple(1, &dims, NULL);
+
+  // Create an int attribute - size
+  hid_t attribute = H5Acreate(dset_id, "size", H5T_NATIVE_INT, dataspace,
+                              H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attribute, H5T_NATIVE_INT, &dat->size);
+  H5Aclose(attribute);
+
+  // Create an int attribute - dimension
+  attribute = H5Acreate(dset_id, "dim", H5T_NATIVE_INT, dataspace, H5P_DEFAULT,
+                        H5P_DEFAULT);
+  H5Awrite(attribute, H5T_NATIVE_INT, &dat->dim);
+  H5Aclose(attribute);
+  H5Sclose(dataspace);
+
+  // Create an string attribute - type
+  dataspace = H5Screate(H5S_SCALAR);
+  hid_t atype = H5Tcopy(H5T_C_S1);
+  int attlen = strlen(dat->type);
+  H5Tset_size(atype, attlen);
+
+  attribute =
+      H5Acreate(dset_id, "type", atype, dataspace, H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attribute, atype, dat->type);
+  H5Aclose(attribute);
+
+  H5Sclose(dataspace);
+  H5Dclose(dset_id);
   H5Fclose(file_id);
 
   // free the temp op_dat used for this write

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -192,32 +192,36 @@ void create_path(op_dat dat, hid_t file_id) {
   herr_t status;
   char *path = (char *)dat->name;
   char *ssc;
-  int l = 0;
   int k = 0;
+  int size = 50;
   int c = 0;
   ssc = strstr(path, "/");
-  char buffer[50];
+  char *buffer = (char *)xmalloc(50 * sizeof(char));
   while (ssc) {
-    char result[20];
     k = strlen(path) - strlen(ssc);
-    strncpy(result, &path[0], k);
-    result[k] = '\0';
     if (k > 0) {
+      char result[30];
+      strncpy(result, &path[0], k);
+      result[k] = '\0';
+      printf("%s\n", result);
+      if (size <= c + k + 1) {
+        size = 2 * (size + c + k + 1);
+        buffer = (char *)xrealloc(buffer, 2 * size * sizeof(char));
+      }
       sprintf(&buffer[c], "/%s", result);
-      c = 1 + k;
-      printf("%d,%s\n", k, buffer);
+      c += 1 + k;
+      printf("%d,%s\n", c, buffer);
+
+      // Create a group named "/result" in the file.
+      group_id =
+          H5Gcreate2(file_id, buffer, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      status = H5Gclose(group_id);
     }
-
-    // Create a group named "/result" in the file.
-    group_id =
-        H5Gcreate2(file_id, buffer, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    status = H5Gclose(group_id);
-
-    l = strlen(ssc) + 1;
-    path = &path[strlen(path) - l + 2];
+    path = &path[strlen(path) - strlen(ssc) + 1];
     ssc = strstr(path, "/");
   }
-  char name[20];
+  free(buffer);
+  char name[30];
   strncpy(name, &path[0], strlen(path));
   name[strlen(path)] = '\0';
   printf("%s\n", name);

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -417,8 +417,7 @@ op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
   /* Save old error handler */
   H5E_auto_t old_func;
   void *old_client_data;
-  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
+  H5error_off(old_func, old_client_data);
 
   /*open data set*/
   dset_id = H5Dopen(file_id, name, H5P_DEFAULT);
@@ -459,7 +458,7 @@ op_map op_decl_map_hdf5(op_set from, op_set to, int dim, char const *file,
   const char *typ = dset_props.type_str;
 
   // Restore previous error handler .. report hdf5 error stack automatically
-  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+  H5error_on(old_func, old_client_data);
 
   /*read in map in hyperslabs*/
 
@@ -559,8 +558,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
   /* Save old error handler */
   H5E_auto_t old_func;
   void *old_client_data;
-  H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL); // turn off HDF5's auto error reporting
+  H5error_off(old_func, old_client_data);
 
   /*open data set*/
   dset_id = H5Dopen(file_id, name, H5P_DEFAULT);
@@ -595,7 +593,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
   }
 
   // Restore previous error handler .. report hdf5 error stack automatically
-  H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
+  H5error_on(old_func, old_client_data);
 
   /*read in dat in hyperslabs*/
 

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -1130,6 +1130,9 @@ void op_fetch_data_hdf5(op_dat data, char const *file_name,
   hsize_t count[2]; // hyperslab selection parameters
   hsize_t offset[2];
 
+  H5E_auto_t old_func;
+  void *old_client_data;
+
   // Set up file access property list with parallel I/O access
   plist_id = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fapl_mpio(plist_id, OP_MPI_HDF5_WORLD, info);
@@ -1150,7 +1153,11 @@ void op_fetch_data_hdf5(op_dat data, char const *file_name,
               file_name, path_name);
     file_id = H5Fopen(file_name, H5F_ACC_RDWR, plist_id);
 
-    if (H5Lexists(file_id, path_name, H5P_DEFAULT) != 0) {
+    H5error_off(old_func, old_client_data);
+    herr_t status = H5Gget_objinfo(file_id, path_name, 0, NULL);
+    H5error_on(old_func, old_client_data);
+
+    if (status == 0) {
       op_printf("op_dat %s exists in the file ... updating data\n", path_name);
 
       dset_id = H5Dopen(file_id, path_name, H5P_DEFAULT);

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -86,7 +86,7 @@ cd $OP2_APPS_DIR/c/aero/aero_hdf5/dp/
 $OP2_C_CODEGEN_DIR/op2.py aero.cpp
 make clean;make
 
-#COMMENT1
+
 
 echo " "
 echo " "
@@ -144,7 +144,7 @@ validate "./airfoil_mpi_openmp OP_PART_SIZE=256"
 export OMP_NUM_THREADS=2
 validate "$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_mpi_openmp OP_PART_SIZE=256"
 
-#COMMENT1
+
 echo " "
 echo " "
 echo "=======================> Running Airfoil HDF5 DP built with Intel Compilers"
@@ -169,7 +169,7 @@ validate "./airfoil_mpi_openmp OP_PART_SIZE=256"
 export OMP_NUM_THREADS=2
 validate "$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_mpi_openmp OP_PART_SIZE=256"
 
-
+#COMMENT1
 echo "=======================> Running Convertmesh built with Intel Compilers"
 cd $OP2_APPS_DIR/c/airfoil/airfoil_hdf5/dp
 make convert_mesh_seq convert_mesh_mpi
@@ -181,12 +181,12 @@ fi
 ./convert_mesh_seq
 ./convert_mesh_seq
 rm ./test.h5
-$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
-$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./convert_mesh_mpi
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./convert_mesh_mpi
 ./convert_mesh_seq
 rm ./test.h5
 ./convert_mesh_seq
-$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
+$MPI_INSTALL_PATH/bin/mpirun -np 20 ./convert_mesh_mpi
 
 
 echo " "

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -30,7 +30,7 @@ cd ../../fortran/python/
 export OP2_FORT_CODEGEN_DIR=$PWD
 cd $OP2_INSTALL_PATH/c
 
-#<<COMMENT1
+
 #<<COMMENT0
 
 echo " "
@@ -40,7 +40,7 @@ echo "***********************> Building C back-end libs with Intel Compilers"
 echo "**********************************************************************"
 . $CURRENT_DIR/source_intel
 make clean; make
-
+#<<COMMENT1
 
 echo " "
 echo " "
@@ -144,7 +144,7 @@ validate "./airfoil_mpi_openmp OP_PART_SIZE=256"
 export OMP_NUM_THREADS=2
 validate "$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_mpi_openmp OP_PART_SIZE=256"
 
-
+#COMMENT1
 echo " "
 echo " "
 echo "=======================> Running Airfoil HDF5 DP built with Intel Compilers"
@@ -170,7 +170,6 @@ export OMP_NUM_THREADS=2
 validate "$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_mpi_openmp OP_PART_SIZE=256"
 
 
-#COMMENT1
 echo "=======================> Running Convertmesh built with Intel Compilers"
 cd $OP2_APPS_DIR/c/airfoil/airfoil_hdf5/dp
 make convert_mesh_seq convert_mesh_mpi
@@ -188,7 +187,6 @@ $MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
 rm ./test.h5
 ./convert_mesh_seq
 $MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
-exit
 
 
 echo " "

--- a/scripts/test_makefiles.sh
+++ b/scripts/test_makefiles.sh
@@ -30,6 +30,7 @@ cd ../../fortran/python/
 export OP2_FORT_CODEGEN_DIR=$PWD
 cd $OP2_INSTALL_PATH/c
 
+#<<COMMENT1
 #<<COMMENT0
 
 echo " "
@@ -115,9 +116,8 @@ $OP2_C_CODEGEN_DIR/op2.py reduction.cpp
 $OP2_C_CODEGEN_DIR/op2.py reduction_mpi.cpp
 make clean;make
 
-#COMMENT1
 
-#<<COMMENT1
+
 
 echo " "
 echo " "
@@ -168,6 +168,27 @@ export OMP_NUM_THREADS=20
 validate "./airfoil_mpi_openmp OP_PART_SIZE=256"
 export OMP_NUM_THREADS=2
 validate "$MPI_INSTALL_PATH/bin/mpirun -np 10 ./airfoil_mpi_openmp OP_PART_SIZE=256"
+
+
+#COMMENT1
+echo "=======================> Running Convertmesh built with Intel Compilers"
+cd $OP2_APPS_DIR/c/airfoil/airfoil_hdf5/dp
+make convert_mesh_seq convert_mesh_mpi
+
+if [ -f "./test.h5" ]
+then
+  rm test.h5
+fi
+./convert_mesh_seq
+./convert_mesh_seq
+rm ./test.h5
+$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
+$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
+./convert_mesh_seq
+rm ./test.h5
+./convert_mesh_seq
+$MPI_INSTALL_PATH/bin/mpirun -np 1 ./convert_mesh_mpi
+exit
 
 
 echo " "


### PR DESCRIPTION
This branch implements features requested in #114 

`void op_fetch_data_hdf5_file(op_dat dat, char const *file_name)` is now capable of dealing with dat->name representing a path inside the h5-file (string with '/'s).

New function `void op_fetch_data_hdf5_file(op_dat dat, char const *file_name, char const *dataset_name)` can be used for dumping an op_dat to an h5-container, where dataset_name is a freely chosen path inside the h5-file of the dataset.
